### PR TITLE
#35 - Refactor: 버튼 컴포넌트화, 로그인 버튼 함수명 변경

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import styled from 'styled-components'
+
+export default function Button({ buttonText, isEmpty, onClick }) {
+  return (
+    <ButtonComponent isEmpty={isEmpty} onClick={onClick}>
+      {buttonText}
+    </ButtonComponent>
+  )
+}
+
+const ButtonComponent = styled.button`
+  background-color: ${(props) =>
+    props.isEmpty ? 'var(--color-enabled)' : 'var(--color-enabled-dark)'};
+  color: #ffffff;
+  border-radius: 44px;
+  width: 100%;
+  border: none;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+  margin-top: 14px;
+  padding: 13px 0;
+`;

--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import styled from 'styled-components';
 import Button from '../Button/Button';
 
-export default function Form() {
+export default function Form({ buttonText }) {
   const url = 'https://mandarin.api.weniv.co.kr';
 
   const [id, setId] = useState('');
@@ -71,7 +71,7 @@ export default function Form() {
       <WarningText isWrong={isWrong}>
         * 이메일 또는 비밀번호가 일치하지 않습니다.
       </WarningText>
-      <Button buttonText='로그인' isEmpty={isEmpty} onClick={onClickLogin}></Button>
+      <Button buttonText={buttonText} isEmpty={isEmpty} onClick={onClickLogin}></Button>
     </Container>
   );
 }

--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import styled from 'styled-components';
+import Button from '../Button/Button';
 
-export default function Form({ buttonText }) {
+export default function Form() {
   const url = 'https://mandarin.api.weniv.co.kr';
 
   const [id, setId] = useState('');
@@ -36,7 +37,7 @@ export default function Form({ buttonText }) {
     setPassword(e.target.value);
   };
 
-  async function getData(e) {
+  async function onClickLogin(e) {
     if (!isEmpty) {
       e.preventDefault();
       try {
@@ -70,9 +71,7 @@ export default function Form({ buttonText }) {
       <WarningText isWrong={isWrong}>
         * 이메일 또는 비밀번호가 일치하지 않습니다.
       </WarningText>
-      <Button onClick={getData} isEmpty={isEmpty}>
-        {buttonText}
-      </Button>
+      <Button buttonText='로그인' isEmpty={isEmpty} onClick={onClickLogin}></Button>
     </Container>
   );
 }
@@ -114,18 +113,4 @@ const WarningText = styled.p`
   line-height: 14px;
   margin-top: -8px;
   display: ${(props) => (props.isWrong ? 'block' : 'none')};
-`;
-
-const Button = styled.button`
-  background-color: ${(props) =>
-    props.isEmpty ? 'var(--color-enabled)' : 'var(--color-enabled-dark)'};
-  color: #ffffff;
-  border-radius: 44px;
-  width: 100%;
-  border: none;
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 18px;
-  margin-top: 14px;
-  padding: 13px 0;
 `;


### PR DESCRIPTION
1. 로그인 버튼 클릭 이벤트 함수명을 getData에서 onClickLogin으로 변경하였습니다.
2. 자주 사용하는 버튼을 컴포넌트화 했습니다.
<img width="319" alt="image" src="https://user-images.githubusercontent.com/89122773/177446615-a8220373-c9e5-469f-bf0a-ba45718e8026.png">

* props 3가지는 다음과 같습니다.

  1. buttonText - 버튼 안에 들어가는 텍스트를 지정할 수 있습니다.
  2. isEmpty - input값이 하나라도 비어있으면 비활성화 상태이고, 옅은 색을 지닙니다. 모두 들어차면 활성화 되고, 짙은 색으로 변합니다. 단, isEmpty 변수는 로그인, 회원가입 컴포넌트 안에만 존재해서 사용하시려면 다시 함수를 짜시거나, 검사해주는 함수를 다시 컴포넌트로 빼서 사용해야겠다는 생각이 드네요..!
  3. onClick - 클릭 시 발생할 함수를 넣을 수 있습니다.
  4. 위의 3가지 props는 필수로 사용할 필요는 없습니다!
  
<img width="308" alt="image" src="https://user-images.githubusercontent.com/89122773/177447258-9ca9dc8a-d2f4-4037-9dcd-2406a9f24c9f.png">

* 저는 로그인 페이지에서 버튼을 위와 같이 활용하였습니다!

* 추가적으로 회원가입 창에 적용을 안 해서 merge 되면 추가로 적용하겠습니다.
* 다른 페이지에 있는 버튼들은 크기가 다른데, props 하나 더 추가해서 props.large면 큰 사이즈, props.medium이면 중간 사이즈 , 이런 식으로 크기도 유동적으로 적용시킬 수 있을 것 같아요!