### PR TITLE
Refactor: Profile 컴포넌트화 및 사용자 프로필 페이지에 적용

### DIFF
--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -1,0 +1,143 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Button from '../Button/Button';
+
+// 이미지
+import basicProfileImg from '../../assets/images/basic-profile-img.png';
+
+export default function Profile({
+  followersCount,
+  followingsCount,
+  userName,
+  userId,
+  userIntroduction,
+}) {
+  const [profileImg, setProfileImg] = useState(basicProfileImg);
+
+  return (
+    <>
+      <UserInfo>
+        <h1 className="ir">사용자 정보</h1>
+        <FollowArea>
+          <FollowersCount>
+            {followersCount}
+            <FollowersTxt>followers</FollowersTxt>
+          </FollowersCount>
+          <MyProfileImg src={profileImg}></MyProfileImg>
+          <FollowersCount color="#767676">
+            {followingsCount}
+            <FollowersTxt>followings</FollowersTxt>
+          </FollowersCount>
+        </FollowArea>
+
+        <UserArea>
+          <UserName>{userName}</UserName>
+          <UserId>@ {userId}</UserId>
+          <UserIntroduction>{userIntroduction}</UserIntroduction>
+        </UserArea>
+
+        <ButtonArea>
+          <Button buttonText="프로필 수정"></Button>
+          <Button buttonText="상품 등록"></Button>
+        </ButtonArea>
+      </UserInfo>
+    </>
+  );
+}
+
+const UserInfo = styled.article`
+  margin-bottom: 6px;
+  padding-top: 30px;
+  outline: 0.5px solid #dbdbdb;
+  background-color: #fff;
+`;
+
+// 1
+const FollowArea = styled.div`
+  margin-bottom: 16px;
+  padding: 0 55px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const FollowersCount = styled.strong`
+  display: flex;
+  flex-direction: column;
+
+  font-weight: 700;
+  font-size: 18px;
+  line-height: 23px;
+  text-align: center;
+  color: ${(props) => props.color || '#000'};
+`;
+
+const FollowersTxt = styled.strong`
+  font-weight: 400;
+  font-size: 8px;
+  line-height: 10px;
+  text-align: center;
+  color: #767676;
+`;
+
+const MyProfileImg = styled.img`
+  padding: 0 41px;
+  width: 100%;
+  max-width: 110px;
+`;
+
+// 2
+const UserArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const UserName = styled.strong`
+  margin-bottom: 6px;
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 20px;
+`;
+
+const UserId = styled.strong`
+  margin-bottom: 16px;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 14px;
+  color: #767676;
+`;
+
+const UserIntroduction = styled.span`
+  margin-bottom: 24px;
+
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+
+  color: #767676;
+`;
+
+// 3
+const ButtonArea = styled.div`
+  margin: 0 auto;
+  padding-bottom: 26px;
+  display: flex;
+  width: 100%;
+  max-width: 280px;
+`;
+
+// const Button = styled.button`
+//   margin-right: ${(props) => props.marginRight || '0px'};
+//   padding: 8px 0;
+//   width: 100%;
+//   max-width: ${(props) => props.maxWidth || '120px'};
+
+//   font-weight: 500;
+//   font-size: 14px;
+//   line-height: 18px;
+//   color: #767676;
+
+//   border: 1px solid #dbdbdb;
+//   border-radius: 30px;
+// `;

--- a/src/pages/MyProfile/MyProfile.jsx
+++ b/src/pages/MyProfile/MyProfile.jsx
@@ -1,149 +1,30 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
+import Profile from '../../components/Profile/Profile';
 
 // 이미지
-import basicProfileImg from '../../assets/images/basic-profile-img.png';
+// import basicProfileImg from '../../assets/images/basic-profile-img.png';
 
 export default function MyProfile() {
-  const [profileImg, setProfileImg] = useState(basicProfileImg);
-  // setProfileImg();
-
   return (
     <>
-      <UserInfo>
-        <h1 className="ir">사용자 정보</h1>
-        <FollowArea>
-          <FollowersCount>
-            2950
-            <FollowersTxt>followers</FollowersTxt>
-          </FollowersCount>
-          <MyProfileImg src={profileImg}></MyProfileImg>
-          <FollowersCount color="#767676">
-            128
-            <FollowersTxt>followers</FollowersTxt>
-          </FollowersCount>
-        </FollowArea>
-
-        <UserArea>
-          <UserName>애월읍 위니브 감귤농장</UserName>
-          <UserId>@ weniv_Mandarin</UserId>
-          <UserIntroduction>
-            애월읍 감귤 전국 배송, 귤따기 체험, 감귤 농장
-          </UserIntroduction>
-        </UserArea>
-
-        <ButtonArea>
-          <Button marginRight="12px">프로필 수정</Button>
-          <Button maxWidth="100px">상품 등록</Button>
-        </ButtonArea>
-      </UserInfo>
-      <BasicArea></BasicArea>
+      <ProfileContainer>
+        <Profile
+          followersCount="2950"
+          followingsCount="128"
+          userName="애월읍 위니브 감귤농장"
+          userId="weniv_Mandarin"
+          userIntroduction="애월읍 감귤 전국 배송, 귤따기 체험, 감귤 농장"
+        ></Profile>
+      </ProfileContainer>
     </>
   );
 }
 
-const UserInfo = styled.article`
+const ProfileContainer = styled.section`
   margin: 0 auto;
-  padding-top: 30px;
   width: 100%;
   max-width: 390px;
-  outline: 0.5px solid #dbdbdb;
-`;
-
-// 1
-const FollowArea = styled.div`
-  margin-bottom: 16px;
-  padding: 0 55px;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-`;
-
-const FollowersCount = styled.strong`
-  display: flex;
-  flex-direction: column;
-
-  font-weight: 700;
-  font-size: 18px;
-  line-height: 23px;
-  text-align: center;
-  color: ${(props) => props.color || '#000'};
-`;
-
-const FollowersTxt = styled.strong`
-  font-weight: 400;
-  font-size: 8px;
-  line-height: 10px;
-  text-align: center;
-  color: #767676;
-`;
-
-const MyProfileImg = styled.img`
-  padding: 0 41px;
-  width: 100%;
-  max-width: 110px;
-`;
-
-// 2
-const UserArea = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const UserName = styled.strong`
-  margin-bottom: 6px;
-  font-weight: 700;
-  font-size: 16px;
-  line-height: 20px;
-`;
-
-const UserId = styled.strong`
-  margin-bottom: 16px;
-  font-weight: 400;
-  font-size: 12px;
-  line-height: 14px;
-  color: #767676;
-`;
-
-const UserIntroduction = styled.span`
-  margin-bottom: 24px;
-
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
-
-  color: #767676;
-`;
-
-// 3
-const ButtonArea = styled.div`
-  padding-bottom: 26px;
-  display: flex;
-  justify-content: center;
-`;
-
-const Button = styled.button`
-  margin-right: ${(props) => props.marginRight || '0px'};
-  padding: 8px 0;
-  width: 100%;
-  max-width: ${(props) => props.maxWidth || '120px'};
-
-  font-weight: 500;
-  font-size: 14px;
-  line-height: 18px;
-  color: #767676;
-
-  border: 1px solid #dbdbdb;
-  border-radius: 30px;
-`;
-
-// 4
-const BasicArea = styled.div`
-  margin: 6px auto 0;
-  width: 100%;
-  max-width: 390px;
-  height: 524px;
+  min-height: 844px; //임시 높이
   background-color: #f2f2f2;
-  outline: 0.5px solid #dbdbdb;
 `;


### PR DESCRIPTION
1. MyProfile과 추후에 구현할 YourProfile에 중복 UI가 많아서 component 폴더에 따로 Profile 컴포넌트를 구현하였습니다. 
  - props 설명
    - followersCount: 팔로워 수를 나타냅니다.
    - followingsCount: 팔로잉 수를 나타냅니다.
    - userName: 사용자의 닉네임입니다.
    - userId: 사용자의 아이디입니다.
    - userIntroduction: 사용자 소개 부분입니다.
    - 위의 props 모두 필수는 아니지만 나중에 값을 필수로 받아와야 하므로 수정할 예정입니다.

2.  MyProfile를 Profile과 Button 컴포넌트를 사용하여 수정하였습니다.
![image](https://user-images.githubusercontent.com/97442475/177482696-c98f8478-11ef-4c1e-8f39-215f90b387b1.png)
  - Button 컴포넌트 적용 후 margin과 width는 해결을 못했습니다. Button 컴포넌트를 수정해야할 것 같습니다!
  
  - 피그마 시안에서 'your profile' 부분의 총 길이는 976px입니다. 상태바(24px), 상단 네비게이션(48px), 하단 탭 메뉴(60px) 를 빼서 **순수 프로필 레이아웃의 min-height를 844px로 고정해놓았습니다**. 최소 높이에 대한 의견 받습니다! (나중에 컨텐츠 추가할 때 깜빡할 것 같아서 메모해놓았습니다)
