### PR TITLE
#47 - Feat: 프로필 설정 페이지 퍼블리싱

### DIFF
--- a/src/components/ProfileForm/ImageButton.jsx
+++ b/src/components/ProfileForm/ImageButton.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import ProfilePic from '../../assets/images/basic-profile-img.png';
+import UploadPic from '../../assets/images/upload-file.png';
+
+export default function ImageButton() {
+  return (
+    <Button>
+      <ProfileImg src={ProfilePic} />
+      <UploadImg src={UploadPic} />
+    </Button>
+  );
+}
+
+const Button = styled.button`
+  display: block;
+  border: none;
+  margin: 0 auto 30px;
+  position: relative;
+  background-color: #ffffff;
+`;
+
+const ProfileImg = styled.img``;
+
+const UploadImg = styled.img`
+  position: absolute;
+  bottom: 0;
+  right: 0;
+`;

--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled from 'styled-components';
+import ImageButton from './ImageButton';
+import UserInfoInput from './UserInfoInput';
+import Button from '../Button/Button';
+
+export default function ProfileForm() {
+  return (
+    <FormContainer>
+      <ImageButton />
+      <UserInfoInput
+        TitleText="사용자 이름"
+        placeholder="2~10자 이내여야 합니다."
+      />
+      <UserInfoInput
+        TitleText="계정 ID"
+        placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
+      />
+      <UserInfoInput
+        TitleText="소개"
+        placeholder="자신이 판매할 상품에 대해 소개해 주세요!"
+      />
+      <Button buttonText="샤인마스켓 시작하기" />
+    </FormContainer>
+  );
+}
+
+const FormContainer = styled.form`
+  padding: 0 34px;
+`;

--- a/src/components/ProfileForm/UserInfoInput.jsx
+++ b/src/components/ProfileForm/UserInfoInput.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export default function UserInfoInput({ TitleText, placeholder }) {
+  return (
+    <>
+      <Title>{TitleText}</Title>
+      <Input placeholder={placeholder} />
+    </>
+  );
+}
+
+const Title = styled.label`
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 15px;
+  color: #767676;
+`;
+
+const Input = styled.input`
+  display: block;
+  width: calc(100% - 20px);
+  margin-bottom: 16px;
+  padding: 10px;
+  background-color: #ffffff;
+  border-left: none;
+  border-right: none;
+  border-top: none;
+  border-bottom: 1px solid #dbdbdb;
+  font-size: 14px;
+  line-height: 14px;
+  color: #dbdbdb;
+`;

--- a/src/pages/ProfileSetting/ProfileSetting.jsx
+++ b/src/pages/ProfileSetting/ProfileSetting.jsx
@@ -1,5 +1,22 @@
 import React from 'react';
+import styled from 'styled-components';
+import Title from '../../components/Title/Title';
+import ProfileForm from '../../components/ProfileForm/ProfileForm';
 
 export default function ProfileSetting() {
-  return <div>ProfileSetting</div>;
+  return (
+    <div>
+      <Title title="프로필 설정" />
+      <SubTitle>나중에 언제든지 변경할 수 있습니다.</SubTitle>
+      <ProfileForm />
+    </div>
+  );
 }
+
+const SubTitle = styled.h2`
+  font-size: 14px;
+  line-height: 14px;
+  text-align: center;
+  margin: 12px 0 30px;
+  color: #767676;
+`;


### PR DESCRIPTION
1. 프로필 설정 페이지 퍼블리싱 완료하였습니다.
2. 프로필 설정 페이지 UI가 퍼블리 수정 페이지와 거의 비슷해서 components 폴더에 ProfileForm 이라는 폴더에 만들었습니다.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/89122773/177580395-213cd359-06ad-472f-9237-afe8f0ceaee3.png">
