### PR TITLE
#56 - Chore: ESLint, Prettier Indent 충돌 해결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,8 +28,6 @@
         "react"
     ],
     "rules": {
-        // 들여쓰기 2칸만 허용
-        "indent": ["error", 2],
         // var 키워드 사용 불가능
         "no-var": "error",
         // asynn 함수 내부에 await 키워드가 없으면 오류 발생


### PR DESCRIPTION
ESLint 와 Prettier 에서 Indent 규칙이 충돌하는 문제가 발생하였습니다!

공식 문서를 확인해보니 Indent 관련 규칙은 Prettier에게 맡기고 ESLint 에서는 삭제하라고 제시하여서 ESLint의 Indent 규칙을 삭제하였습니다!!

2칸 띄어쓰기는 바뀌지 않고 똑같습니다!

앞으로는 ```npx prettier --write src``` 로 코드 정리하시면 됩니다.