### PR TITLE
#62 Refactor: 상단 메뉴 컴포넌트 수정 #62

### DIFF
--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -3,13 +3,13 @@ import styled from 'styled-components';
 import LeftArrow from '../../assets/icon/icon-arrow-left.png';
 import Button from '../Button/Button';
 
-export default function TopMenuBar() {
+export default function TopMenuBar({ saveButton }) {
   return (
     <Container>
       <PreviousBtn>
         <PrevioudBtnImg src={LeftArrow} />
       </PreviousBtn>
-      <Button buttonText="저장" size="medium-small" />
+      {saveButton ? <Button buttonText="저장" size="medium-small" /> : null}
     </Container>
   );
 }
@@ -25,4 +25,5 @@ const PreviousBtn = styled.button``;
 
 const PrevioudBtnImg = styled.img`
   vertical-align: -4px;
+  padding: 5px 0;
 `;

--- a/src/pages/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/ModifyProfile/ModifyProfile.jsx
@@ -5,7 +5,7 @@ import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
 export default function ModifyProfile() {
   return (
     <div>
-      <TopMenuBar />
+      <TopMenuBar saveButton={true} />
       <ProfileForm isButton={false} />
     </div>
   );


### PR DESCRIPTION
* 버튼이 있는 상단바와 없는 상단바를 사용할 수 있도록 수정하였습니다!

![image](https://user-images.githubusercontent.com/89122773/177892891-e3c87d1c-5b17-4a89-bac9-24218c4951ab.png)

![image](https://user-images.githubusercontent.com/89122773/177892976-714c9071-638a-4766-b20d-15745adf1e47.png)

props로 saveButton의 불리언 값을 전달하여 true면 상단바에 저장 버튼이 있고, false면 저장 버튼이 없습니다.

* 상단바 우측에 여러가지 버튼들이 있는데, props로 추가하셔서 true false 주시면서 사용하시면 될 것 같습니다!