### PR TITLE
#65 - Refactor: 게시글 댓글 페이지 컴포넌트화

### DIFF
--- a/src/components/Button/MoreButton.jsx
+++ b/src/components/Button/MoreButton.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import styled from 'styled-components';
+import MoreIcon from '../../assets/icon/icon-more-vertical.png';
+import MoreIconSmall from '../../assets/icon/s-icon-more-vertical.png';
+
+export default function Button({ onClick, size }) {
+  return (
+    <ButtonComponent onClick={onClick} size={size}>
+      {size === 'large' ? (
+        <Img src={MoreIcon} />
+      ) : size === 'small' ? (
+        <Img src={MoreIconSmall} />
+      ) : null}
+    </ButtonComponent>
+  );
+}
+
+const ButtonComponent = styled.button`
+  width: ${(props) =>
+    props.size === 'large' ? '22px' : props.size === 'small' ? '18px' : null};
+  margin-top: 5px;
+  border: none;
+  margin-left: auto;
+`;
+
+const Img = styled.img`
+  width: ${(props) =>
+    props.size === 'large' ? '22px' : props.size === 'small' ? '18px' : null};
+`;

--- a/src/components/Comment/Comment.jsx
+++ b/src/components/Comment/Comment.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+import MoreButton from '../Button/MoreButton';
+import BasicProfileImg from '../../assets/images/basic-profile-img.png';
+
+export default function PostComment() {
+  return (
+    <CommentList>
+      <CommentItem>
+        <CommentProfile>
+          <ProfileImg src={BasicProfileImg} />
+          <CommentName>서귀포시 무슨 농장</CommentName>
+          <CommentDate>· 5분 전</CommentDate>
+          <MoreButton size="large" />
+        </CommentProfile>
+        <CommentText>게시글 답글 ~~ !! 최고최고</CommentText>
+      </CommentItem>
+    </CommentList>
+  );
+}
+
+const CommentList = styled.ul`
+  padding: 20px 16px;
+`;
+
+const CommentItem = styled.li`
+  margin-bottom: 16px;
+`;
+
+const CommentProfile = styled.div`
+  display: flex;
+`;
+
+const CommentName = styled.strong`
+  margin: 6px 0 0 12px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
+`;
+
+const CommentDate = styled.span`
+  margin: 8.5px 0 0 6px;
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 13px;
+  color: #767676;
+`;
+
+const CommentText = styled.p`
+  margin-left: 48px;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  color: #333;
+`;
+
+const ProfileImg = styled.img`
+  width: 36px;
+  height: 36px;
+  border: 0.5px solid #dbdbdb;
+  border-radius: 50%;
+`;

--- a/src/components/PostTextBar/PostTextBar.jsx
+++ b/src/components/PostTextBar/PostTextBar.jsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import BasicProfileImg from '../../assets/images/basic-profile-img.png';
+import PhotoIcon from '../../assets/images/img-button.png';
+
+export default function PostComment({ name, placeholder, buttonText }) {
+  const [chatText, setChatText] = useState('');
+  const [isEmpty, setIsEmpty] = useState(true);
+
+  const onChange = (e) => {
+    setChatText(e.target.value);
+  };
+
+  useEffect(() => {
+    if (chatText) {
+      setIsEmpty(true);
+    } else {
+      setIsEmpty(false);
+    }
+  }, [chatText]);
+  return (
+    <UploadComment>
+      {name === 'post' ? (
+        <ProfileImg src={BasicProfileImg} />
+      ) : name === 'chat' ? (
+        <PhotoBtn type="button">이미지 첨부</PhotoBtn>
+      ) : null}
+      <label htmlFor="comment-text" className="ir">
+        메시지 입력창
+      </label>
+      <Input
+        type="text"
+        id="comment-text"
+        placeholder={placeholder}
+        onChange={onChange}
+      />
+      <SendBtn type="button" isEmpty={isEmpty}>
+        {buttonText}
+      </SendBtn>
+    </UploadComment>
+  );
+}
+
+const UploadComment = styled.div`
+  display: flex;
+  position: fixed;
+  bottom: 0;
+  width: 100%;
+  align-items: center;
+  padding: 13px 16px 12px;
+  border-top: 1px solid #dbdbdb;
+  box-sizing: border-box;
+  background-color: white;
+`;
+
+const ProfileImg = styled.img`
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 0.5px solid #dbdbdb;
+`;
+
+const PhotoBtn = styled.button`
+  width: 36px;
+  height: 36px;
+  border: none;
+  background: url(${PhotoIcon});
+  background-size: 36px 36px;
+  font-size: 0;
+`;
+
+const Input = styled.input`
+  flex-grow: 1;
+  margin: 0 18px;
+  padding: 10px 0 8px;
+  border: none;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 18px;
+  &:focus {
+    outline: none;
+    color: black;
+  }
+  &::placeholder {
+    color: #c4c4c4;
+  }
+  &:focus::placeholder {
+    color: transparent;
+  }
+`;
+
+const SendBtn = styled.button`
+  margin-left: auto;
+  border: none;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 18px;
+  background-color: transparent;
+  color: ${(props) => (props.isEmpty ? 'var(--color-enabled)' : '#c4c4c4')};
+`;

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -1,15 +1,28 @@
 import React from 'react';
+import { Link, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-import LeftArrow from '../../assets/icon/icon-arrow-left.png';
 import Button from '../Button/Button';
 
-export default function TopMenuBar({ saveButton }) {
+import LeftArrow from '../../assets/icon/icon-arrow-left.png';
+import MoreButton from '../Button/MoreButton';
+
+export default function TopMenuBar({
+  saveButton,
+  moreButton,
+  moreButtonSmall,
+  menuText,
+}) {
+  const history = useHistory();
+
   return (
     <Container>
-      <PreviousBtn>
+      <PreviousBtn onClick={() => history.goBack()}>
         <PrevioudBtnImg src={LeftArrow} />
       </PreviousBtn>
+      <MenuText>{menuText}</MenuText>
       {saveButton ? <Button buttonText="저장" size="medium-small" /> : null}
+      {moreButton ? <MoreButton size="large" /> : null}
+      {moreButtonSmall ? <MoreButton size="small" /> : null}
     </Container>
   );
 }
@@ -17,13 +30,24 @@ export default function TopMenuBar({ saveButton }) {
 const Container = styled.article`
   display: flex;
   justify-content: space-between;
+  align-items: center;
   border-bottom: 1px solid #dbdbdb;
   padding: 8px 20px;
 `;
 
-const PreviousBtn = styled.button``;
+const PreviousBtn = styled(Link)`
+  width: 22px;
+  border: none;
+`;
 
 const PrevioudBtnImg = styled.img`
   vertical-align: -4px;
   padding: 5px 0;
+`;
+
+const MenuText = styled.h1`
+  margin-left: 10px;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 18px;
 `;

--- a/src/pages/ChatList/ChatList.jsx
+++ b/src/pages/ChatList/ChatList.jsx
@@ -1,23 +1,44 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
 import TabMenu from '../../components/TabMenu/TabMenu';
-
 import BasicProfileImg from '../../assets/images/basic-profile-img.png';
-import LeftArrow from '../../assets/icon/icon-arrow-left.png';
-import MoreIcon from '../../assets/icon/icon-more-vertical.png';
 
-const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  padding: 13px 12px 13px 16px;
-  border-bottom: 1px solid #dbdbdb;
-`;
+export default function ChatList() {
+  return (
+    <>
+      <TopMenuBar moreButton="true" />
+      <Section>
+        <h1 className="ir">채팅 목록</h1>
+        <ChatLink to="/chat-room">
+          <TextContainer>
+            <ChatName>애월읍 위니브 샤인머스캣 농장</ChatName>
+            <ChatTxt>이번에 정정 언제하맨마씸?</ChatTxt>
+            <ChatDate>2020.10.25</ChatDate>
+          </TextContainer>
+        </ChatLink>
 
-const Img = styled.img`
-  width: 22px;
-  height: 22px;
-`;
+        <ChatLink to="#/">
+          <TextContainer>
+            <ChatName>제주감귤마을</ChatName>
+            <ChatTxt>깊은 어둠의 존재감, 롤스로이스 뉴 블랙 배지...</ChatTxt>
+            <ChatDate>2020.10.25</ChatDate>
+          </TextContainer>
+        </ChatLink>
+
+        <ChatLink to="#/">
+          <TextContainer>
+            <ChatName>누구네 농장 친환경 한라봉</ChatName>
+            <ChatTxt>내 차는 내가 평가한다. 오픈 이벤트에 참여 하...</ChatTxt>
+            <ChatDate>2020.10.25</ChatDate>
+          </TextContainer>
+        </ChatLink>
+      </Section>
+      <TabMenu />
+    </>
+  );
+}
 
 const Section = styled.section`
   padding: 24px 16px 0;
@@ -42,6 +63,7 @@ const ChatLink = styled(Link)`
     height: 42px;
     border-radius: 50px;
     box-sizing: border-box;
+    border: 0.5px solid #dbdbdb;
   }
   &:not(:last-child)::after {
     content: '';
@@ -79,49 +101,8 @@ const ChatTxt = styled.p`
 
 const ChatDate = styled.span`
   float: right;
-  margin-left: auto;
   font-size: 10px;
   line-height: 13px;
   text-align: right;
   color: #dbdbdb;
 `;
-
-export default function ChatList() {
-  return (
-    <>
-      <Header>
-        <Link to="#/">
-          <Img src={LeftArrow} alt="뒤로 가기" />
-        </Link>
-        <Img src={MoreIcon} alt="더 보기 아이콘" />
-      </Header>
-      <Section>
-        <h1 className="ir">채팅 목록</h1>
-        <ChatLink to="/chat-room">
-          <TextContainer>
-            <ChatName>애월읍 위니브 감귤농장</ChatName>
-            <ChatTxt>이번에 정정 언제하맨마씸?</ChatTxt>
-            <ChatDate>2020.10.25</ChatDate>
-          </TextContainer>
-        </ChatLink>
-
-        <ChatLink to="#/">
-          <TextContainer>
-            <ChatName>제주감귤마을</ChatName>
-            <ChatTxt>깊은 어둠의 존재감, 롤스로이스 뉴 블랙 배지...</ChatTxt>
-            <ChatDate>2020.10.25</ChatDate>
-          </TextContainer>
-        </ChatLink>
-
-        <ChatLink to="#/">
-          <TextContainer>
-            <ChatName>누구네 농장 친환경 한라봉</ChatName>
-            <ChatTxt>내 차는 내가 평가한다. 오픈 이벤트에 참여 하...</ChatTxt>
-            <ChatDate>2020.10.25</ChatDate>
-          </TextContainer>
-        </ChatLink>
-      </Section>
-      <TabMenu />
-    </>
-  );
-}

--- a/src/pages/ChatRoom/ChatRoom.jsx
+++ b/src/pages/ChatRoom/ChatRoom.jsx
@@ -1,37 +1,51 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import ChatModal from './ChatModal';
+import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
+import PostTextBar from '../../components/PostTextBar/PostTextBar';
 
 import BasicProfileImg from '../../assets/images/basic-profile-img.png';
-import PhotoIcon from '../../assets/images/img-button.png';
 import SendImg from '../../assets/images/chat-exapmle.png';
-import LeftArrow from '../../assets/icon/icon-arrow-left.png';
-import MoreIcon from '../../assets/icon/icon-more-vertical.png';
 
-const Header = styled.header`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 13px 12px 13px 16px;
-  border-bottom: 1px solid #dbdbdb;
-`;
-
-const Img = styled.img`
-  width: 22px;
-`;
-
-const ChatRoomName = styled.h1`
-  flex-grow: 1;
-  margin-left: 10px;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 18px;
-  vertical-align: middle;
-`;
+export default function ChatRoom() {
+  return (
+    <>
+      <TopMenuBar menuText="애월읍 위니브 샤인머스캣 농장" moreButton="true" />
+      <ChatSection>
+        <p className="ir">채팅창</p>
+        <FriendChatBox>
+          <ProfileImg src={BasicProfileImg}></ProfileImg>
+          <ChatTxt>
+            옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
+            이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는
+            풍부하게 뛰노는 인생의 힘있다.
+          </ChatTxt>
+          <TimeTxt>12:39</TimeTxt>
+        </FriendChatBox>
+        <FriendChatBox>
+          <ProfileImg src={BasicProfileImg}></ProfileImg>
+          <ChatTxt>샤인머스캣 사고싶어요요요요요요요</ChatTxt>
+          <TimeTxt>12:41</TimeTxt>
+        </FriendChatBox>
+        <MyChatBox>
+          <ChatTxt>네 말씀하세요.</ChatTxt>
+          <TimeTxt>12:50</TimeTxt>
+        </MyChatBox>
+        <MyChatBox>
+          <ChatImg src={SendImg} alt="전송된 이미지" />
+          <TimeTxt>12:51</TimeTxt>
+        </MyChatBox>
+      </ChatSection>
+      <PostTextBar
+        name="chat"
+        placeholder="메시지 입력하기"
+        buttonText="전송"
+      />
+    </>
+  );
+}
 
 const ChatSection = styled.section`
-  padding: 224px 16px 20px 16px;
+  padding: 160px 16px 82px 16px;
   background-color: #f2f2f2;
   font-size: 14px;
   font-weight: 400;
@@ -97,137 +111,3 @@ const MyChatBox = styled.div`
 const ChatImg = styled.img`
   border-radius: 10px;
 `;
-
-const CommentSection = styled.section`
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  padding: 13px 16px 12px;
-  border-top: 1px solid #dbdbdb;
-`;
-
-const Label = styled.label`
-  position: absolute;
-  top: -9999px;
-  overflow: hidden;
-`;
-
-const Input = styled.input`
-  flex-grow: 1;
-  margin: 0 18px;
-  padding: 10px 0 8px;
-  border: none;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
-  &:focus {
-    outline: none;
-    color: black;
-  }
-  &::placeholder {
-    color: #c4c4c4;
-  }
-  &:focus::placeholder {
-    color: transparent;
-  }
-`;
-
-const PhotoBtn = styled.button`
-  width: 36px;
-  height: 36px;
-  border: none;
-  background: url(${PhotoIcon});
-  background-size: 36px 36px;
-`;
-
-const SendBtn = styled.button`
-  margin-left: auto;
-  border: none;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 18px;
-  background-color: transparent;
-  color: ${(props) => (props.isEmpty ? 'var(--color-enabled)' : '#c4c4c4')};
-`;
-
-const MoreBtn = styled.button`
-  width: 22px;
-  height: 22px;
-  border: none;
-  background: url(${MoreIcon});
-  background-size: 22px 22px;
-`;
-
-export default function ChatRoom() {
-  const [modalBox, setModalBox] = useState(false);
-  const [chatText, setChatText] = useState('');
-  const [isEmpty, setIsEmpty] = useState(true);
-
-  const onChange = (e) => {
-    setChatText(e.target.value);
-  };
-
-  useEffect(() => {
-    if (chatText) {
-      setIsEmpty(true);
-    } else {
-      setIsEmpty(false);
-    }
-  }, [chatText]);
-
-  return (
-    <>
-      <Header>
-        <Link to="/chat-list">
-          <Img src={LeftArrow} alt="뒤로 가기" />
-        </Link>
-        <ChatRoomName>애월읍 위니브 감귤농장</ChatRoomName>
-        <MoreBtn
-          onClick={() => {
-            setModalBox(!modalBox);
-          }}
-        ></MoreBtn>
-      </Header>
-      <ChatSection>
-        <p className="ir">채팅창</p>
-        <FriendChatBox>
-          <ProfileImg src={BasicProfileImg}></ProfileImg>
-          <ChatTxt>
-            옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-            이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는
-            풍부하게 뛰노는 인생의 힘있다.
-          </ChatTxt>
-          <TimeTxt>12:39</TimeTxt>
-        </FriendChatBox>
-        <FriendChatBox>
-          <ProfileImg src={BasicProfileImg}></ProfileImg>
-          <ChatTxt>안녕하세요. 감귤 사고싶어요요요요요</ChatTxt>
-          <TimeTxt>12:41</TimeTxt>
-        </FriendChatBox>
-        <MyChatBox>
-          <ChatTxt>네 말씀하세요.</ChatTxt>
-          <TimeTxt>12:50</TimeTxt>
-        </MyChatBox>
-        <MyChatBox>
-          <ChatImg src={SendImg} alt="전송된 이미지" />
-          <TimeTxt>12:51</TimeTxt>
-        </MyChatBox>
-      </ChatSection>
-      <CommentSection>
-        <p className="ir">채팅 입력창</p>
-        <PhotoBtn type="button"></PhotoBtn>
-        <Label htmlFor="comment-text">메시지 입력창</Label>
-        <Input
-          type="text"
-          id="comment-text"
-          placeholder="메시지 입력하기"
-          onChange={onChange}
-        />
-        <SendBtn type="button" isEmpty={isEmpty}>
-          전송
-        </SendBtn>
-      </CommentSection>
-      {modalBox && <ChatModal />}
-    </>
-  );
-}

--- a/src/pages/Post/Post.jsx
+++ b/src/pages/Post/Post.jsx
@@ -1,49 +1,59 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
-import Modal from '../ChatRoom/ChatModal';
+import PostTextBar from '../../components/PostTextBar/PostTextBar';
+import Comment from '../../components/Comment/Comment';
+import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
+import MoreButton from '../../components/Button/MoreButton';
 
 import BasicProfileImg from '../../assets/images/basic-profile-img.png';
-import LeftArrow from '../../assets/icon/icon-arrow-left.png';
-import MoreIcon from '../../assets/icon/icon-more-vertical.png';
-import MoreIconSmall from '../../assets/icon/s-icon-more-vertical.png';
 import PostImg from '../../assets/images/post-img-example.png';
 import HeartIcon from '../../assets/icon/icon-heart.png';
 import CommentIcon from '../../assets/icon/icon-message-circle.png';
 
-const Header = styled.header`
-  display: flex;
-  position: fixed;
-  width: 100%;
-  padding: 13px 12px 13px 16px;
-  border-bottom: 1px solid #dbdbdb;
-  box-sizing: border-box;
-  background-color: white;
-`;
-
-const BackLink = styled(Link)`
-  width: 22px;
-  height: 22px;
-  border: none;
-  background: url(${LeftArrow});
-  background-size: 22px 22px;
-`;
-
-const MoreBtn = styled.button`
-  width: 22px;
-  height: 22px;
-  margin-left: auto;
-  border: none;
-  background: url(${MoreIcon});
-  background-size: 22px 22px;
-  background-repeat: no-repeat;
-`;
+export default function Post() {
+  return (
+    <>
+      <TopMenuBar moreButton="true" />
+      <Container>
+        <h1 className="ir">게시글</h1>
+        <Profile>
+          <TextContainer>
+            <UserName>애월읍 위니브 감귤농장</UserName>
+            <UserId>@ weniv_Mandarin</UserId>
+          </TextContainer>
+          <MoreButton size="small" />
+        </Profile>
+        <PostContainer>
+          <PostText>
+            옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
+            이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는
+            풍부하게 뛰노는 인생의 힘있다.
+          </PostText>
+          <Img src={PostImg} />
+        </PostContainer>
+        <ButtonContainer>
+          <LikeBtn>
+            <LikeCount>58</LikeCount>
+          </LikeBtn>
+          <CommentBtn>
+            <CommentCount>12</CommentCount>
+          </CommentBtn>
+        </ButtonContainer>
+        <Date>2020년 10월 21일</Date>
+      </Container>
+      <Comment />
+      <PostTextBar
+        name="post"
+        placeholder="댓글 입력하기..."
+        buttonText="게시"
+      />
+    </>
+  );
+}
 
 const Container = styled.section`
-  padding: 69px 16px 20px;
-  box-sizing: border-box;
+  padding: 20px 16px;
   border-bottom: 1px solid #dbdbdb;
-  overflow: scroll;
 `;
 
 const Profile = styled.div`
@@ -60,17 +70,9 @@ const Profile = styled.div`
     background-repeat: no-repeat;
     width: 42px;
     height: 42px;
-    box-sizing: border-box;
+    border: 0.5px solid #dbdbdb;
+    border-radius: 50%;
   }
-`;
-
-const ProfileMoreBtn = styled.button`
-  width: 18px;
-  height: 18px;
-  margin-left: auto;
-  background: url(${MoreIconSmall});
-  background-size: 18px 18px;
-  background-repeat: no-repeat;
 `;
 
 const TextContainer = styled.div`
@@ -111,7 +113,7 @@ const PostText = styled.p`
 const Img = styled.img`
   display: block;
   width: 304px;
-  margin-bottom: 14.73px;
+  margin-bottom: 14.7px;
 `;
 
 const ButtonContainer = styled.div`
@@ -162,180 +164,3 @@ const Date = styled.p`
   line-height: 12px;
   color: #767676;
 `;
-
-const CommentList = styled.ul`
-  padding: 20px 16px;
-`;
-
-const CommentItem = styled.li`
-  margin-bottom: 16px;
-`;
-
-const CommentProfile = styled.div`
-  display: flex;
-`;
-
-const CommentName = styled.strong`
-  margin: 6px 0 0 12px;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 18px;
-`;
-
-const CommentDate = styled.span`
-  margin: 8.5px 0 0 6px;
-  font-size: 10px;
-  font-weight: 400;
-  line-height: 13px;
-  color: #767676;
-`;
-
-const CommentText = styled.p`
-  margin-left: 48px;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 18px;
-  color: #333;
-`;
-
-const UploadComment = styled.div`
-  display: flex;
-  position: fixed;
-  bottom: 0;
-  width: 100%;
-  align-items: center;
-  padding: 13px 16px 12px;
-  border-top: 1px solid #dbdbdb;
-  box-sizing: border-box;
-  background-color: white;
-`;
-
-const ProfileImg = styled.img`
-  width: 36px;
-  height: 36px;
-`;
-
-const Input = styled.input`
-  flex-grow: 1;
-  margin: 0 18px;
-  padding: 10px 0 8px;
-  border: none;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 18px;
-  &:focus {
-    outline: none;
-    color: black;
-  }
-  &::placeholder {
-    color: #c4c4c4;
-  }
-  &:focus::placeholder {
-    color: transparent;
-  }
-`;
-
-const SendBtn = styled.button`
-  margin-left: auto;
-  border: none;
-  font-size: 14px;
-  font-weight: 400;
-  line-height: 18px;
-  background-color: transparent;
-  color: ${(props) => (props.isEmpty ? 'var(--color-enabled)' : '#c4c4c4')};
-`;
-
-export default function Post() {
-  const [modalBox, setModalBox] = useState(false);
-  const [chatText, setChatText] = useState('');
-  const [isEmpty, setIsEmpty] = useState(true);
-
-  const onChange = (e) => {
-    setChatText(e.target.value);
-  };
-
-  useEffect(() => {
-    if (chatText) {
-      setIsEmpty(true);
-    } else {
-      setIsEmpty(false);
-    }
-  }, [chatText]);
-
-  return (
-    <>
-      <Header>
-        <BackLink to="/my-profile"></BackLink>
-        <MoreBtn
-          onClick={() => {
-            setModalBox(!modalBox);
-          }}
-        ></MoreBtn>
-      </Header>
-
-      <Container>
-        <h1 className="ir">게시글</h1>
-        <Profile>
-          <TextContainer>
-            <UserName>애월읍 위니브 감귤농장</UserName>
-            <UserId>@ weniv_Mandarin</UserId>
-          </TextContainer>
-          <ProfileMoreBtn
-            onClick={() => {
-              setModalBox(!modalBox);
-            }}
-          ></ProfileMoreBtn>
-        </Profile>
-        <PostContainer>
-          <PostText>
-            옷을 인생을 그러므로 없으면 것은 이상은 것은 우리의 위하여, 뿐이다.
-            이상의 청춘의 뼈 따뜻한 그들의 그와 약동하다. 대고, 못할 넣는
-            풍부하게 뛰노는 인생의 힘있다.
-          </PostText>
-          <Img src={PostImg} />
-        </PostContainer>
-        <ButtonContainer>
-          <LikeBtn>
-            <LikeCount>58</LikeCount>
-          </LikeBtn>
-
-          <CommentBtn>
-            <CommentCount>12</CommentCount>
-          </CommentBtn>
-        </ButtonContainer>
-        <Date>2020년 10월 21일</Date>
-      </Container>
-      <CommentList>
-        <CommentItem>
-          <CommentProfile>
-            <ProfileImg src={BasicProfileImg} />
-            <CommentName>서귀포시 무슨 농장</CommentName>
-            <CommentDate>· 5분 전</CommentDate>
-            <MoreBtn
-              onClick={() => {
-                setModalBox(!modalBox);
-              }}
-            ></MoreBtn>
-          </CommentProfile>
-          <CommentText>게시글 답글 ~~ !! 최고최고</CommentText>
-        </CommentItem>
-      </CommentList>
-      <UploadComment>
-        <ProfileImg src={BasicProfileImg} />
-        <label htmlFor="comment-text" className="ir">
-          메시지 입력창
-        </label>
-        <Input
-          type="text"
-          id="comment-text"
-          placeholder="댓글 입력하기..."
-          onChange={onChange}
-        />
-        <SendBtn type="button" isEmpty={isEmpty}>
-          게시
-        </SendBtn>
-      </UploadComment>
-      {modalBox && <Modal />}
-    </>
-  );
-}


### PR DESCRIPTION
컴포넌트화 완료했습니다!

1. Button 컴포넌트 폴더 안에 MoreButton 파일 추가
- 준상님이 만드신 button 컴포넌트 참고해서 더 보기 버튼도 large, small로 구분해서 사용할 수 있도록 했습니다

2. 각각 따로 구현되어 있던 헤더들을 TopMenuBar로 적용
- PreviousBtn에 이전에 방문했던 페이지로 돌아갈 수 있도록 구현했는데 혹시 예외의 경우가 있으면 말씀해 주세요!
- 더 보기 버튼이 있는 헤더는 props로 받아 추가할 수 있도록 했습니다 (moreButton, moreButtonSmall)

3. 게시글 댓글 페이지의 댓글 등록 섹션과 채팅방의 채팅 입력 섹션 컴포넌트화 (PostTextBar.jsx)

4. 컴포넌트화 과정에서 생긴 디자인적 문제 해결 및 필요 없는 코드 제거

하다 보니 대수정이 돼 버렸습니다 ㅎㅎ 오류 발견하시면 알려 주세요!
