### PR TITLE
#67 - 프로필 설정 + 회원가입 기능 구현

### DIFF
--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -17,14 +17,18 @@ export default function Form({
 }) {
   const location = useLocation();
 
+  // 고객이 폼에 입력하는 ID, PW 데이터 변수화
+  // 고객이 폼에 모두 값을 입력했는지에 대한 불리언 값 변수화
   const [id, setId] = useState('');
   const [password, setPassword] = useState('');
   const [isEmpty, setIsEmpty] = useState(true);
 
+  // URL 경로에 따라서 부모의 PROPS 함수를 다르게 받음
   location.pathname === '/login'
     ? getUserInfo(id, password)
     : getJoinInfo(id, password);
 
+  // 고객이 폼에 입력할때마다 모두 값을 입력했는지에 대한 불리언 값 업데이트
   useEffect(() => {
     if (id && password) {
       setIsEmpty(false);
@@ -33,6 +37,7 @@ export default function Form({
     }
   }, [id, password]);
 
+  // ID, PW 동적으로 업데이트
   const onHandleUserId = (e) => {
     setId(e.target.value);
   };

--- a/src/components/ProfileForm/InputTitle.jsx
+++ b/src/components/ProfileForm/InputTitle.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import styled from 'styled-components';
+
+export default function InputTitle({ TitleText }) {
+  return (
+    <Title>{TitleText}</Title>
+  )
+}
+
+const Title = styled.label`
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 15px;
+  color: #767676;
+`;

--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -1,27 +1,78 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import axios from 'axios';
 import ImageButton from './ImageButton';
 import UserInfoInput from './UserInfoInput';
 import Button from '../Button/Button';
+import InputTitle from './InputTitle';
 
 export default function ProfileForm({ isButton }) {
+  // 전역 데이터로 담긴 가입 ID, PW 가져오기
+  const { registerId, registerPassword } = useSelector(state => ({
+    registerId: state.UserInfoReducer.registerId,
+    registerPassword: state.UserInfoReducer.registerPassword
+  }));
+
+  // 사용자가 설정한 이름, 계정 ID, 소개 변수에 담기
+  const [userName, setUserName] = useState("");
+  const [userAccount, setUserAccount] = useState("");
+  const [userIntro, setUserIntro] = useState("");
+
+  // 사용자가 입력하는 데이터 동적으로 변수에 저장
+  const onHandleUserName = e => {
+    setUserName(e.target.value);
+  }
+
+  const onHandleUserAccount = e => {
+    setUserAccount(e.target.value);
+  }
+
+  const onHandleUserIntro = e => {
+    setUserIntro(e.target.value);
+  }
+
+  // 시작 버튼
+  // 기능 1. 회원가입 API 통신 (서버에 유저 정보 보내기)
+  const onClickStartButton = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.post('https://mandarin.api.weniv.co.kr/user', {
+        user: {
+          username: userName,
+          email: registerId,
+          password: registerPassword,
+          accountname: userAccount,
+          intro: userIntro,
+          image: ""
+        }
+      })
+      console.log(res);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
   return (
     <FormContainer>
       <ImageButton />
-      <UserInfoInput
+      <InputTitle TitleText="사용자 이름" />
+      <UserInfoInput onChange={onHandleUserName}
         TitleText="사용자 이름"
         placeholder="2~10자 이내여야 합니다."
       />
-      <UserInfoInput
+      <InputTitle TitleText="계정 ID" />
+      <UserInfoInput onChange={onHandleUserAccount}
         TitleText="계정 ID"
         placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
       />
-      <UserInfoInput
+      <InputTitle TitleText="소개" />
+      <UserInfoInput onChange={onHandleUserIntro}
         TitleText="소개"
         placeholder="자신이 판매할 상품에 대해 소개해 주세요!"
       />
       {isButton ? (
-        <Button size="large" buttonText="샤인마스켓 시작하기" />
+        <Button size="large" buttonText="샤인마스켓 시작하기" onClick={onClickStartButton} />
       ) : null}
     </FormContainer>
   );

--- a/src/components/ProfileForm/UserInfoInput.jsx
+++ b/src/components/ProfileForm/UserInfoInput.jsx
@@ -1,21 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export default function UserInfoInput({ TitleText, placeholder }) {
+export default function UserInfoInput({ placeholder, onChange }) {
   return (
     <>
-      <Title>{TitleText}</Title>
-      <Input placeholder={placeholder} />
+      <Input placeholder={placeholder} onChange={onChange} />
     </>
   );
 }
-
-const Title = styled.label`
-  font-weight: 500;
-  font-size: 12px;
-  line-height: 15px;
-  color: #767676;
-`;
 
 const Input = styled.input`
   display: block;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
+import rootReducer from './store';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
-root.render(<App />);
+
+const store = createStore(rootReducer);
+root.render(
+  <Provider store={store}>
+    <App />
+  </Provider>
+);

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -1,11 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux/es/exports';
 import axios from 'axios';
 import Form from '../../components/Form/Form';
 import Title from '../../components/Title/Title';
 
 export default function Join() {
   const history = useHistory();
+  const dispatch = useDispatch();
 
   const [joinId, setJoinId] = useState('');
   const [joinPassword, setJoinPassword] = useState('');
@@ -13,10 +15,12 @@ export default function Join() {
   const [passwordAvailable, setPasswordAvailable] = useState(true);
   const [isUser, setIsUser] = useState(false);
 
+  // 이메일 값이 변경되면 가입된 고객인가에 대한 불리언 값 false로 초기화
   useEffect(() => {
     setIsUser(false);
   }, [joinId]);
 
+  // Form(자식 컴포넌트)에서 id, password 값 props로 받아오기
   const getJoinInfo = (id, password) => {
     useEffect(() => {
       setJoinId(id);
@@ -24,6 +28,7 @@ export default function Join() {
     }, [id, password]);
   };
 
+  // focus 잃으면 이메일, 비밀번호 유효성 검사 진행
   const checkIsAvailable = () => {
     const email = joinId;
     const password = joinPassword;
@@ -42,6 +47,9 @@ export default function Join() {
     }
   };
 
+  // 다음 클릭 버튼
+  // 기능 1. 이메일 검증 API 통신 (서버에 가입 이메일 정보 보내기)
+  // 기능 2. 가입된 이메일 주소면? => 다시, 사용 가능하면 Redux에 ID, PW 데이터 담고 프로필 설정 페이지로 이동
   const onClickJoin = async (e) => {
     e.preventDefault();
     try {
@@ -61,6 +69,10 @@ export default function Join() {
         res.data.message === '사용 가능한 이메일 입니다.' &&
         emailAvailable
       ) {
+        const registerId = joinId;
+        const registerPassword = joinPassword;
+
+        dispatch({ type: "CLICK", registerId, registerPassword});
         history.push('/join/profile');
       }
       console.log(joinId, joinPassword, isUser);

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -6,11 +6,14 @@ import Form from '../../components/Form/Form';
 import Title from '../../components/Title/Title';
 
 export default function Login() {
+  // 고객이 폼에 입력하는 ID, PW 데이터 변수화
+  // 고객이 입력한 이메일 유효성, 비밀번호 일치 여부에 대한 불리언 값 변수화
   const [loginId, setLoginId] = useState('');
   const [loginPassword, setLoginPassword] = useState('');
   const [isWrong, setIsWrong] = useState(false);
   const [isEmail, setIsEmail] = useState(false);
 
+  // Form(자식 컴포넌트)로부터 id, password 받아오는 함수
   const getUserInfo = (id, password) => {
     useEffect(() => {
       setLoginId(id);
@@ -18,6 +21,10 @@ export default function Login() {
     }, [id, password]);
   };
 
+  // 로그인 버튼 클릭
+  // 기능 1. 클릭 시 이메일 유효성 검사
+  // 기능 2. 로그인 API 통신 (ID, PW 서버에 보내기)
+  // 기능 3. 비밀번호 일치하지 않으면 경고 문구 출력
   const onClickLogin = async (e) => {
     e.preventDefault();
     const email = loginId;

--- a/src/store/UserInfo.js
+++ b/src/store/UserInfo.js
@@ -1,0 +1,19 @@
+const initialState = {
+    registerId: "",
+    registerPassword: ""
+}
+
+const UserInfoReducer = (state = initialState, action) => {
+    switch(action.type) {
+        case "CLICK":
+          return {
+            ...state,
+            registerId: action.registerId,
+            registerPassword: action.registerPassword
+          }
+        default:
+            return state;
+    }
+}
+
+export default UserInfoReducer;

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,8 @@
+import { combineReducers } from "redux";
+import UserInfoReducer from "./UserInfo";
+
+const rootReducer = combineReducers({
+  UserInfoReducer,
+})
+
+export default rootReducer;


### PR DESCRIPTION
1. 회원가입 페이지의 아이디와 비밀번호를 프로필 설정에서도 관리하기 위해서 index.js에 리덕스 세팅을 하였습니다.
2. store 폴더에 리덕스 사용을 위한 index.js와 UserInfoReducer.js 추가하였습니다.
3. 프로필 설정 페이지에서 onChange 이벤트를 따로 지정하기 위해서 input 태그를 컴포넌트화 했습니다.
4. 각 기능을 설명하는 주석을 추가하였습니다.
5. 회원가입 API를 사용하여 아이디, 비밀번호, 이름, 계정, 소개 데이터를 보내주면 회원가입이 진행되도록 구현하였습니다.

* ### 추가 구현할 기능
  1. 계정명 유효성 검사
  2. 계정 유효성 검사 API 사용