### PR TITLE
#74 - Feat: 팔로워 목록 페이지 퍼블리싱

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import MyProfile from './pages/MyProfile/MyProfile';
 import Post from './pages/Post/Post';
 import ModifyProfile from './pages/ModifyProfile/ModifyProfile';
 import Upload from './pages/Upload/Upload';
+import Follower from './pages/Follower/Follower.jsx';
 
 function App() {
   return (
@@ -33,6 +34,7 @@ function App() {
       <Route path="/chat-room" exact component={ChatRoom} />
       <Route path="/my-profile" exact component={MyProfile} />
       <Route path="/profile/modify" exact component={ModifyProfile} />
+      <Route path="/follower" exact component={Follower} />
     </BrowserRouter>
   );
 }

--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -1,13 +1,20 @@
 import React from 'react';
 import styled from 'styled-components';
 
-export default function Button({ buttonText, isEmpty, onClick, size }) {
+export default function Button({
+  buttonText,
+  isEmpty,
+  onClick,
+  size,
+  className,
+}) {
   return (
     <ButtonComponent
       isEmpty={isEmpty}
       onClick={onClick}
       disabled={isEmpty ? 'disabled' : null}
       size={size}
+      className={className}
     >
       {buttonText}
     </ButtonComponent>
@@ -33,7 +40,7 @@ const ButtonComponent = styled.button`
   border: none;
   font-weight: 500;
   font-size: ${(props) => (props.size === 'small' ? '12px' : '14px')};
-  line-height: 18px;
+  line-height: ${(props) => (props.size === 'small' ? '15px' : '18px')};
   padding: ${(props) =>
     props.size === 'large'
       ? '13px 0'

--- a/src/components/FollowList/FollowList.jsx
+++ b/src/components/FollowList/FollowList.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+import UserCell from '../UserCell/UserCell';
+
+export default function FollowList() {
+  return (
+    <>
+      {/* 팔로우리스트 컴포넌트 */}
+      <FollowListComponent>
+        <UserCell userName="애월" UserIntroduction="맛집!!!!!!!!"></UserCell>
+        <UserCell userName="배고파" UserIntroduction="밥줘!!!!!!!!"></UserCell>
+        <UserCell
+          userName="싱싱한 제 주 한 라 보오오오옹"
+          UserIntroduction="맛있겠다!!!!!!!!"
+        ></UserCell>
+      </FollowListComponent>
+    </>
+  );
+}
+
+const FollowListComponent = styled.article`
+  margin-top: 16px;
+`;

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -48,7 +48,8 @@ const PrevioudBtnImg = styled.img`
 `;
 
 const MenuText = styled.h1`
-  margin-left: 10px;
+  margin-right: auto;
+  padding-left: 10px;
   font-size: 14px;
   font-weight: 500;
   line-height: 18px;

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -11,6 +11,7 @@ export default function TopMenuBar({
   moreButton,
   moreButtonSmall,
   menuText,
+  className,
 }) {
   const history = useHistory();
 
@@ -29,6 +30,7 @@ export default function TopMenuBar({
 
 const Container = styled.article`
   display: flex;
+
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid #dbdbdb;

--- a/src/components/UserCell/UserCell.jsx
+++ b/src/components/UserCell/UserCell.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import basicProfileImg from '../../assets/images/basic-profile-img.png';
+import Button from '../Button/Button';
+
+export default function UserCell(props) {
+  return (
+    <>
+      <UserCellComponent>
+        <UserProfileImg src={basicProfileImg}></UserProfileImg>
+        <UserArea>
+          <UserName>{props.userName}</UserName>
+          <UserIntroduction>{props.UserIntroduction}</UserIntroduction>
+        </UserArea>
+
+        <FollowButton size="small" buttonText="팔로우"></FollowButton>
+      </UserCellComponent>
+    </>
+  );
+}
+
+const UserCellComponent = styled.article`
+  margin: 8px 16px;
+  align-items: center;
+  display: flex;
+`;
+
+const UserProfileImg = styled.img`
+  margin-right: 12px;
+  width: 50px;
+`;
+
+const UserArea = styled.div`
+  margin-right: 30px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const UserName = styled.strong`
+  margin-bottom: 6px;
+  font-weight: 500;
+  font-size: 14px;
+  line-height: 18px;
+`;
+
+const UserIntroduction = styled.span`
+  margin-bottom: 6px;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 15px;
+  color: #767676;
+`;
+
+const FollowButton = styled(Button)`
+  margin-left: auto;
+`;

--- a/src/pages/Follower/Follower.jsx
+++ b/src/pages/Follower/Follower.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import styled from 'styled-components';
+import FollowList from '../../components/FollowList/FollowList';
+import TabMenu from '../../components/TabMenu/TabMenu';
+import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
+
+export default function Follower() {
+  return (
+    <>
+      <TopMenuBar menuText="Followers"></TopMenuBar>
+      <FollowList></FollowList>
+      <TabMenu></TabMenu>
+    </>
+  );
+}


### PR DESCRIPTION
* 실수로 feature-74에서 작업했던 내용들이 feature-43에 커밋됐습니다. 죄송합니다..! (a1274c227d10b963e5251a8e1b06866deed179d7 <- 필요하시면 이 커밋 참고해주시면 될 것 같아요..)
1. App.jsx에 라우터 추가했습니다
    - 일단 path="/follower" 이렇게 설정해놨는데, 트위터 참고해서 "/사용자아이디/follower" 이런식으로  사용자 페이지 뒤로 연결해보겠습니다.

2. Follower 페이지 추가했습니다.
 ![image](https://user-images.githubusercontent.com/97442475/178156653-06e498cd-8f42-4120-9aaa-3e7e7175ad27.png)
   - 사진처럼 Follower를 왼쪽으로 땡겨와야 되는데, 임포트 시킨 TopMenuBar 컴포넌트의 Container에 justify-content: space-between이 들어가 있어서 안되네용. 조건문 써서 어떻게 해보려 했는데 실패했습니다... 다시 재도전할 예정

3. FollowList 컴포넌트 추가하였습니다.
    - Following에서 재탕할 예정

4. UserCell 컴포넌트 추가하였습니다.  (유저 한 명을 담은 컴포넌트)

5. Button 컴포넌트 수정했습니다.
    - 피그마에서 small 버튼만 line-height가 15px
    - 그리고 import한 컴포넌트를 추가로 꾸밀 수 있는 styled()를 사용하기 위해 className 프랍 추가했습니다. ( UserCell 에선 잘 되는데, 다른 파일에는 className 붙여도 안되네요.. 뭐지.. 더 공부해야겠어요)
