### PR TITLE
#83 - Feat: 프로필 수정 기능 구현 + Redux 테스트

### DIFF
--- a/src/components/Form/Form.jsx
+++ b/src/components/Form/Form.jsx
@@ -155,7 +155,7 @@ const WarningText = styled.p`
   font-size: 12px;
   line-height: 14px;
   margin-top: -24px;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
   display: ${(props) => (props.isWrong ? 'block' : 'none')};
 `;
 
@@ -164,6 +164,6 @@ const CheckPasswordAvailable = styled.p`
   font-size: 12px;
   line-height: 14px;
   margin-top: -24px;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
   display: ${(props) => (props.passwordAvailable ? 'none' : 'block')};
 `;

--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -7,7 +7,7 @@ import UserInfoInput from './UserInfoInput';
 import Button from '../Button/Button';
 import InputTitle from './InputTitle';
 
-export default function ProfileForm({ isButton }) {
+export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
   const dispatch = useDispatch();
   // 전역 데이터로 담긴 가입 ID, PW 가져오기
   const { registerId, registerPassword } = useSelector((state) => ({
@@ -31,6 +31,16 @@ export default function ProfileForm({ isButton }) {
     } else {
       setIsEmpty(true);
     }
+  }, [userName, userAccount, userIntro]);
+
+  // 부모 컴포넌트인 ModifyProfile에 isEmpty 정보 전달
+  useEffect(() => {
+    getEmptyInfo(isEmpty);
+  }, [isEmpty]);
+
+  // 부모 컴포넌트인 ModifyProfile에 userName, userAccount, userIntro 정보 전달
+  useEffect(() => {
+    getUserInfo(userName, userAccount, userIntro);
   }, [userName, userAccount, userIntro]);
 
   // 사용자 이름 2~10자 이내 검사
@@ -158,5 +168,5 @@ const WarningText = styled.p`
   font-size: 12px;
   line-height: 14px;
   margin-top: -10px;
-  margin-bottom: 30px;
+  margin-bottom: 20px;
 `;

--- a/src/components/ProfileForm/UserInfoInput.jsx
+++ b/src/components/ProfileForm/UserInfoInput.jsx
@@ -21,7 +21,6 @@ const Input = styled.input`
   border-bottom: 1px solid #dbdbdb;
   font-size: 14px;
   line-height: 14px;
-  color: #dbdbdb;
   &:focus {
     border-bottom-color: var(--color-enabled-dark);
   }

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -12,6 +12,8 @@ export default function TopMenuBar({
   moreButtonSmall,
   menuText,
   className,
+  isEmpty,
+  onClick,
 }) {
   const history = useHistory();
 
@@ -21,7 +23,14 @@ export default function TopMenuBar({
         <PrevioudBtnImg src={LeftArrow} />
       </PreviousBtn>
       <MenuText>{menuText}</MenuText>
-      {saveButton ? <Button buttonText="저장" size="medium-small" /> : null}
+      {saveButton ? (
+        <Button
+          buttonText="저장"
+          size="medium-small"
+          isEmpty={isEmpty}
+          onClick={onClick}
+        />
+      ) : null}
       {moreButton ? <MoreButton size="large" /> : null}
       {moreButtonSmall ? <MoreButton size="small" /> : null}
     </Container>

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -40,7 +40,7 @@ export default function Join() {
       setEmailAvailable(false);
     }
 
-    if (password.length >= 6) {
+    if (password.length >= 6 || !password) {
       setPasswordAvailable(true);
     } else {
       setPasswordAvailable(false);
@@ -67,7 +67,8 @@ export default function Join() {
         setIsUser(true);
       } else if (
         res.data.message === '사용 가능한 이메일 입니다.' &&
-        emailAvailable
+        emailAvailable &&
+        passwordAvailable
       ) {
         const registerId = joinId;
         const registerPassword = joinPassword;

--- a/src/pages/ModifyProfile/ModifyProfile.jsx
+++ b/src/pages/ModifyProfile/ModifyProfile.jsx
@@ -1,12 +1,61 @@
-import React from 'react';
+import React, { useState } from 'react';
+import axios from 'axios';
 import ProfileForm from '../../components/ProfileForm/ProfileForm';
 import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
 
 export default function ModifyProfile() {
+  const [isEmpty, setIsEmpty] = useState(true);
+  const [userName, setUserName] = useState('');
+  const [userAccount, setUserAccount] = useState('');
+  const [userIntro, setUserIntro] = useState('');
+
+  // 자식 컴포넌트에서 전달받은 isEmpty를 useState로 관리
+  const getEmptyInfo = (isEmpty) => {
+    setIsEmpty(isEmpty);
+  };
+
+  // 자식 컴포넌트에서 전달받은 유저 정보 useState로 관리
+  const getUserInfo = (userName, userAccount, userIntro) => {
+    setUserName(userName);
+    setUserAccount(userAccount);
+    setUserIntro(userIntro);
+  };
+
+  // 저장 받은 클릭 시 프로필 수정 적용
+  const onClickSaveButton = async (e) => {
+    e.preventDefault();
+    try {
+      const res = await axios.put('https://mandarin/api/weniv/co/kr/user', {
+        user: {
+          username: userName,
+          accountname: userAccount,
+          intro: userIntro,
+          image: '',
+        },
+        header: {
+          Authorization: 'Bearer {token}',
+          'Content-type': 'application/json',
+        },
+      });
+
+      console.log(res);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <div>
-      <TopMenuBar saveButton={true} />
-      <ProfileForm isButton={false} />
+      <TopMenuBar
+        saveButton={true}
+        isEmpty={isEmpty}
+        onClick={onClickSaveButton}
+      />
+      <ProfileForm
+        isButton={false}
+        getEmptyInfo={getEmptyInfo}
+        getUserInfo={getUserInfo}
+      />
     </div>
   );
 }


### PR DESCRIPTION
1. 프로필 수정 페이지에서 모든 Input에 값이 들어와야 버튼이 활성화되도록 하였습니다.
2. 회원가입 페이지에서 비밀번호가 6자리 이상이여야 버튼이 활성화되도록 하였습니다.
3. 프로필 수정 페이지에서 프로필 수정 API 연동하였습니다.

* ### 후에 진행할 것
1. 프로필 수정 페이지에서 유효성 검사를 모두 통과해야 버튼이 활성화되도록 구현
2. Redux로 회원가입부터 프로필 수정까지 쭉 해보기