### PR TITLE
#93 - Refactor: 버튼 태그의 alt값 삭제

### DIFF
--- a/src/components/Button/Button.jsx
+++ b/src/components/Button/Button.jsx
@@ -6,7 +6,6 @@ export default function Button({
   isEmpty,
   onClick,
   size,
-  buttonImg,
   className,
 }) {
   return (
@@ -18,7 +17,6 @@ export default function Button({
       className={className}
     >
       {buttonText}
-      <ButtonImg src={buttonImg} alt="클릭 버튼" />
     </ButtonComponent>
   );
 }
@@ -60,5 +58,3 @@ const ButtonComponent = styled.button`
       ? '8px 0'
       : null};
 `;
-
-const ButtonImg = styled.img``;


### PR DESCRIPTION
버튼 태그에서 alt값 삭제 확인하다가 필요없는 이미지 태그가 들어가있어서 아예 삭제하였습니다!