### PR TITLE
#106 - 로그인, 회원가입 시 Redux 코드 수정, 페이지 간 이동 설정

### DIFF
--- a/src/components/ProfileForm/ImageButton.jsx
+++ b/src/components/ProfileForm/ImageButton.jsx
@@ -17,8 +17,8 @@ export default function ImageButton({ getImageSrc }) {
     const reader = new FileReader();
     reader.readAsDataURL(fileBlob);
     return new Promise((resolve) => {
-      reader.onload = () => {
-        setImgSrc(reader.result);
+      reader.onload = (e) => {
+        setImgSrc(e.target.result);
         resolve();
       };
     });
@@ -37,22 +37,18 @@ export default function ImageButton({ getImageSrc }) {
       <HiddenInput
         type="file"
         id="image"
-        accept="img/*"
+        accept="image/jpg, image/png, image/jpeg"
         ref={photoInput}
         onChange={(e) => {
           encodeFileToBase64(e.target.files[0]);
         }}
       />
-      <ProfileImg
-        style={
-          imgSrc
-            ? { backgroundImage: `url(${imgSrc})` }
-            : { backgroundImage: `url(${ProfilePic})` }
-        }
-      />
-      <UploadImgButton onClick={onHandleImageButton}>
-        <UploadImg src={UploadPic} alt="프로필 사진 업로드 이미지" />
-      </UploadImgButton>
+      <ProfileImgContainer>
+        <ProfileImg src={imgSrc ? imgSrc : ProfilePic} />
+        <UploadImgButton onClick={onHandleImageButton}>
+          <UploadImg src={UploadPic} alt="프로필 사진 업로드 이미지" />
+        </UploadImgButton>
+      </ProfileImgContainer>
     </ButtonContainer>
   );
 }
@@ -69,22 +65,24 @@ const HiddenInput = styled.input`
   display: none;
 `;
 
-const ProfileImg = styled.div`
+const ProfileImgContainer = styled.div`
   width: 110px;
   height: 110px;
   border-radius: 50%;
-  overflow: hidden;
   margin: 0 auto;
   position: relative;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-size: cover;
+`;
+
+const ProfileImg = styled.img`
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
 `;
 
 const UploadImgButton = styled.button`
   position: absolute;
-  top: 23%;
-  right: 40%;
+  bottom: -12%;
+  right: -15%;
   border-radius: 50%;
   overflow: hidden;
 `;

--- a/src/components/ProfileForm/ImageButton.jsx
+++ b/src/components/ProfileForm/ImageButton.jsx
@@ -6,11 +6,12 @@ import UploadPic from '../../assets/images/upload-file.png';
 export default function ImageButton({ getImageSrc }) {
   const photoInput = useRef();
   const [imgSrc, setImgSrc] = useState('');
+  const [fileName, setFileName] = useState('');
 
   // 부모 컴포넌트인 ProfileForm으로 이미지 src 데이터 전달
   useEffect(() => {
-    getImageSrc(imgSrc);
-  }, [imgSrc]);
+    getImageSrc(fileName);
+  }, [fileName]);
 
   // 이미지 미리 보기 함수
   const encodeFileToBase64 = (fileBlob) => {
@@ -18,6 +19,8 @@ export default function ImageButton({ getImageSrc }) {
     reader.readAsDataURL(fileBlob);
     return new Promise((resolve) => {
       reader.onload = (e) => {
+        console.log(fileBlob.name);
+        setFileName(fileBlob.name);
         setImgSrc(e.target.result);
         resolve();
       };

--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useHistory } from 'react-router-dom';
 import styled from 'styled-components';
 import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
@@ -11,10 +11,12 @@ import InputTitle from './InputTitle';
 export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
   const dispatch = useDispatch();
   const location = useLocation();
+  const history = useHistory();
+
   const photoInput = useRef();
   // 전역 데이터로 담긴 가입 ID, PW 가져오기
-  const { registerId, registerPassword } = useSelector((state) => ({
-    registerId: state.UserInfoReducer.registerId,
+  const { UserId, registerPassword } = useSelector((state) => ({
+    UserId: state.UserInfoReducer.UserId,
     registerPassword: state.UserInfoReducer.registerPassword,
   }));
 
@@ -26,11 +28,11 @@ export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
   const [isId, setIsId] = useState(true);
   const [isEmpty, setIsEmpty] = useState(false);
   const [isExist, setIsExist] = useState(false);
-  const [imageSrc, setImageSrc] = useState('');
+  const [imgSrc, setImgSrc] = useState('');
 
   // 자식 컴포넌트에서 이미지 src 받아오기
   const getImageSrc = (imgSrc) => {
-    setImageSrc(imgSrc);
+    setImgSrc(imgSrc);
   };
 
   // Input 값이 모두 있어야 버튼 활성화
@@ -96,29 +98,35 @@ export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
   const onClickStartButton = async (e) => {
     e.preventDefault();
     const formData = new FormData();
-    formData.append('uploadImage', imageSrc);
+    formData.append('uploadImage', imgSrc);
     try {
       const res = await axios.post('https://mandarin.api.weniv.co.kr/user', {
         user: {
           username: userName,
-          email: registerId,
+          email: UserId,
           password: registerPassword,
           accountname: userAccount,
           intro: userIntro,
-          image: '',
+          image: imgSrc,
         },
       });
 
       console.log(res);
-      const registerUserName = userName;
-      const registerAccountName = userAccount;
-      const registerIntro = userIntro;
+      const UserName = userName;
+      const UserAccount = userAccount;
+      const UserIntro = userIntro;
+      const UserImage = imgSrc;
       dispatch({
         type: 'CLICK',
-        registerUserName,
-        registerAccountName,
-        registerIntro,
+        UserName,
+        UserAccount,
+        UserIntro,
+        UserImage,
       });
+
+      if (res.data.message === '회원가입 성공') {
+        history.push('/login');
+      }
     } catch (error) {
       console.log(error);
       if (error.response.data.message === '이미 사용중인 계정 ID입니다.') {

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -77,7 +77,6 @@ export default function Join() {
         dispatch({ type: 'JOIN', UserId, registerPassword });
         history.push('/join/profile');
       }
-      console.log(joinId, joinPassword, isUser);
     } catch (error) {
       console.log(error);
     }

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -71,10 +71,10 @@ export default function Join() {
         emailAvailable &&
         passwordAvailable
       ) {
-        const registerId = joinId;
+        const UserId = joinId;
         const registerPassword = joinPassword;
 
-        dispatch({ type: 'JOIN', registerId, registerPassword });
+        dispatch({ type: 'JOIN', UserId, registerPassword });
         history.push('/join/profile');
       }
       console.log(joinId, joinPassword, isUser);

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
 import axios from 'axios';
 import { useDispatch } from 'react-redux';
 import styled from 'styled-components';
@@ -8,6 +9,7 @@ import Title from '../../components/Title/Title';
 
 export default function Login() {
   const dispatch = useDispatch();
+  const history = useHistory();
   // 고객이 폼에 입력하는 ID, PW 데이터 변수화
   // 고객이 입력한 이메일 유효성, 비밀번호 일치 여부에 대한 불리언 값 변수화
   const [loginId, setLoginId] = useState('');
@@ -47,12 +49,13 @@ export default function Login() {
         }
       );
       if (!res.data.message) {
-        const userId = res.data.user.email;
+        const UserId = res.data.user.email;
         const loginToken = res.data.user.token;
         const refreshToken = res.data.user.refreshToken;
-        dispatch({ type: 'LOGIN', userId, loginToken });
+        dispatch({ type: 'LOGIN', UserId, loginToken });
         localStorage.setItem('accessToken', loginToken);
         localStorage.setItem('refreshToken', refreshToken);
+        history.push('/home-empty');
       }
       if (res.data.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
         setIsWrong(true);

--- a/src/store/UserInfo.js
+++ b/src/store/UserInfo.js
@@ -1,12 +1,11 @@
 const initialState = {
-  userId: '',
-  loginToken: '',
-  registerId: '',
+  UserId: '',
   registerPassword: '',
-  registerToken: '',
-  registerUserName: '',
-  registerAccountName: '',
-  registerIntro: '',
+  loginToken: '',
+  UserName: '',
+  UserAccount: '',
+  UserIntro: '',
+  UserImage: '',
 };
 
 const UserInfoReducer = (state = initialState, action) => {
@@ -14,22 +13,23 @@ const UserInfoReducer = (state = initialState, action) => {
     case 'LOGIN':
       return {
         ...state,
-        userId: action.userId,
+        UserId: action.UserId,
         loginToken: action.loginToken,
       };
     case 'JOIN':
       return {
         ...state,
-        registerId: action.registerId,
+        UserId: action.UserId,
         registerPassword: action.registerPassword,
       };
 
     case 'CLICK':
       return {
         ...state,
-        registerUserName: action.registerUserName,
-        registerAccountName: action.registerAccountName,
-        registerIntro: action.registerIntro,
+        UserName: action.UserName,
+        UserAccount: action.UserAccount,
+        UserIntro: action.UserIntro,
+        UserImage: action.UserImage,
       };
     default:
       return state;


### PR DESCRIPTION
## #106 - 로그인, 회원가입 시 Redux 코드 수정, 페이지 간 이동 설정
* 페이지 간 이동 흐름을 다음과 같이 설정하였습니다.
  1. 회원가입 진행 -> 성공 -> 로그인 페이지 -> 성공 -> 피드 페이지<br> (회원가입 성공 시 바로 피드 페이지로 넘어가고 싶었지만, 회원가입 성공 시에는 토큰을 제공하지 않아 다시 로그인 페이지로 이동해 로그인을 하도록 했습니다.)
  2. 로그인 진행 -> 성공 -> 피드 페이지

* 로그인, 회원가입 시 Redux 코드를 수정하였습니다.
<img width="254" alt="image" src="https://user-images.githubusercontent.com/89122773/179034245-7cbecab0-fac2-4607-a9b5-c5d8915e9cd5.png">
  1. 로그인 시: 유저 아이디, 토큰 스토어에 저장<br>
  2. 회원가입 시: 유저 아이디, 유저 비밀번호 스토어에 저장<br>
  3. 프로필 설정 시: 유저 이미지 경로, 유저 이름, 유저 Id, 유저 소개글 스토어에 저장<br><br>

* 프로필 업로드 버튼 디자인 조금 수정했습니다.
* 파일 용량 줄이기는 지금 계속 시도중인데 좀 어려워서 70kB 정도의 사진 크기로는 회원가입이 성공한 상태입니다. 회원가입 테스트 하고 싶으시면 사진 말씀주세요. 보내드릴게요.

## #110 - 프로필 이미지 업로드 용량 문제 해결
* 인코딩 전에 파일 이름을 서버에 보내주는 방식으로 해결하였습니다.
<img width="241" alt="image" src="https://user-images.githubusercontent.com/89122773/179157207-59bbd5e2-833c-4970-8515-756d410ca895.png">

* ### 이제 사진에 용량 제한 없을거예요! 

 