### PR TITLE
Refactor: 사용자 id에 따른 프로필 path 변경 및 데이터 출력

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,7 +10,7 @@ import ChatList from './pages/ChatList/ChatList';
 import Join from './pages/Join/Join';
 import ProfileSetting from './pages/ProfileSetting/ProfileSetting';
 import ChatRoom from './pages/ChatRoom/ChatRoom';
-import MyProfile from './pages/MyProfile/MyProfile';
+import ToProfile from './pages/ToProfile/ToProfile';
 import YourProfile from './pages/YourProfile/YourProfile';
 import Post from './pages/Post/Post';
 import ModifyProfile from './pages/ModifyProfile/ModifyProfile';
@@ -37,7 +37,8 @@ function App() {
             <Route path="/upload" exact component={Upload} />
             <Route path="/chat-list" exact component={ChatList} />
             <Route path="/chat-room" exact component={ChatRoom} />
-            <Route path="/my-profile" exact component={MyProfile} />
+            <Route path="/profile/:accountname" exact component={ToProfile} />
+            <Route path="/profile" exact component={ToProfile} />
             <Route path="/my-profile/add-product" exact component={AddProduct} />
             <Route path="/your-profile" exact component={YourProfile} />
             <Route path="/profile/modify" exact component={ModifyProfile} />

--- a/src/components/Button/MoreButton.jsx
+++ b/src/components/Button/MoreButton.jsx
@@ -6,7 +6,6 @@ import MoreIconSmall from '../../assets/icon/s-icon-more-vertical.png';
 import Modal from '../../components/Modal/Modal';
 
 export default function Button({ onClick, size }) {
-
   const [modal, setModal] = useState(false);
   return (
     <ButtonComponent onClick={onClick} size={size}>

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -2,58 +2,61 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export default function Modal(display){
-  return(
+export default function Modal(display) {
+  return (
     <>
-        <ChatModal display={display}>
-          <ChatModal_Ul>
-            <li><Link to="/my-profile">설정 및 개인정보</Link></li>
-            <li><Link to="/">로그아웃</Link></li>
-          </ChatModal_Ul>
-        </ChatModal>
+      <ChatModal display={display}>
+        <ChatModal_Ul>
+          <li>
+            <Link to="/my-profile">설정 및 개인정보</Link>
+          </li>
+          <li>
+            <Link to="/">로그아웃</Link>
+          </li>
+        </ChatModal_Ul>
+      </ChatModal>
     </>
-  )
+  );
 }
 
 const ChatModal = styled.aside`
   display: none;
-  position:absolute;
-  top:0px;
-  left:0px;
-  right:0px;
-  bottom:0px;
-  background:rgba(0,0,0,0.3);
-`
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background: rgba(0, 0, 0, 0.3);
+`;
 
 const ChatModal_Ul = styled.ul`
-  position:fixed;
-  z-index:10;
-  padding:30px;
+  position: fixed;
+  z-index: 10;
+  padding: 30px;
   box-sizing: border-box;
-  left:0px;
-  right:0px;
-  bottom:0px;
-  background:#fff;
+  left: 0px;
+  right: 0px;
+  bottom: 0px;
+  background: #fff;
   border-top-left-radius: 20px;
   border-top-right-radius: 20px;
-  overflow:hidden;
-  &::before{
-    display:block;
-    content:'';
-    position:absolute;
-    width:50px;
-    height:4px;
-    background:#DBDBDB;
-    left:50%;
-    transform:translateX(-50%);
+  overflow: hidden;
+  &::before {
+    display: block;
+    content: '';
+    position: absolute;
+    width: 50px;
+    height: 4px;
+    background: #dbdbdb;
+    left: 50%;
+    transform: translateX(-50%);
   }
-  >li {
-    font-family:"Spoqa Han Sans Neo";
+  > li {
+    font-family: 'Spoqa Han Sans Neo';
     font-style: normal;
     font-weight: 400;
     font-size: 14px;
     line-height: 18px;
-    margin-top:28px;
+    margin-top: 28px;
   }
-
-`
+`;

--- a/src/components/TabMenu/TabMenu.jsx
+++ b/src/components/TabMenu/TabMenu.jsx
@@ -10,6 +10,10 @@ import IconMyprofile from '../../assets/icon/icon-user.svg';
 import IconMyprofileHover from '../../assets/icon/icon-user-fill.png';
 
 // import { Link } from 'react-router-dom';
+import { Link, useHistory, useParams } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import axios from 'axios';
+import { useLocation } from 'react-router';
 
 const Footer = styled.ul`
   position: absolute;
@@ -81,6 +85,45 @@ const GoMyprofileIcon = styled.a`
 `;
 
 export default function TabMenu() {
+  const { UserAccount } = useSelector((state) => ({
+    UserAccount: state.UserInfoReducer.UserAccount,
+  }));
+
+  const history = useHistory();
+  const dispatch = useDispatch();
+  const location = useLocation();
+
+  const goToProfile = async () => {
+    try {
+      const accessToken = localStorage.getItem('accessToken');
+      const res = await axios.get(`https://mandarin.api.weniv.co.kr/profile/${UserAccount}`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-type': 'application/json',
+        },
+      });
+
+      console.log(res);
+      const UserFollowing = res.data.profile.following;
+      const UserFollower = res.data.profile.follower;
+      const UserFollowerCount = res.data.profile.followerCount;
+      const UserFollowingCount = res.data.profile.followingCount;
+      console.log(UserFollowingCount);
+
+      dispatch({
+        type: 'FOLLOW',
+        UserFollowing,
+        UserFollower,
+        UserFollowerCount,
+        UserFollowingCount,
+      });
+
+      history.push(`/profile/${UserAccount}`);
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <Footer>
       <GoHome>
@@ -95,7 +138,7 @@ export default function TabMenu() {
         <GoUploadIcon />
         <p>게시물 작성</p>
       </GoUpload>
-      <GoMyprofile>
+      <GoMyprofile onClick={goToProfile}>
         <GoMyprofileIcon />
         <p>프로필</p>
       </GoMyprofile>

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -45,13 +45,23 @@ export default function Login() {
           password: loginPassword,
         },
       });
+
       if (!res.data.message) {
         console.log(res);
         const UserId = res.data.user.email;
+        const UserAccount = res.data.user.accountname;
+        const UserIntro = res.data.user.intro;
         const UserImage = res.data.user.image;
         const loginToken = res.data.user.token;
         const refreshToken = res.data.user.refreshToken;
-        dispatch({ type: 'LOGIN', UserId, UserImage, loginToken });
+        dispatch({
+          type: 'LOGIN',
+          UserId,
+          UserImage,
+          loginToken,
+          UserAccount,
+          UserIntro,
+        });
         localStorage.setItem('accessToken', loginToken);
         localStorage.setItem('refreshToken', refreshToken);
         history.push('/home-empty');

--- a/src/pages/ToProfile/ToProfile.jsx
+++ b/src/pages/ToProfile/ToProfile.jsx
@@ -4,25 +4,28 @@ import Profile from '../../components/Profile/Profile';
 import TopMenuBar from '../../components/TopMenuBar/TopMenuBar';
 import TabMenu from '../../components/TabMenu/TabMenu';
 import Button from '../../components/Button/Button';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-export default function MyProfile() {
-  const history = useHistory();
-  const { UserId, UserName, UserAccount, UserIntro, UserImage } = useSelector((state) => ({
-    UserName: state.UserInfoReducer.UserName,
-    UserId: state.UserInfoReducer.UserId,
-    UserAccount: state.UserInfoReducer.UserAccount,
-    UserIntro: state.UserInfoReducer.UserIntro,
-    UserImage: state.UserInfoReducer.UserImage,
-  }));
+export default function ToProfile() {
+  const { UserName, UserAccount, UserIntro, UserImage, UserFollowerCount, UserFollowingCount } =
+    useSelector((state) => ({
+      UserName: state.UserInfoReducer.UserName,
+      UserId: state.UserInfoReducer.UserId,
+      UserAccount: state.UserInfoReducer.UserAccount,
+      UserIntro: state.UserInfoReducer.UserIntro,
+      UserImage: state.UserInfoReducer.UserImage,
+      UserFollowerCount: state.UserInfoReducer.UserFollowerCount,
+      UserFollowingCount: state.UserInfoReducer.UserFollowingCount,
+    }));
+
   return (
     <>
       <TopMenuBar />
       <ProfileContainer>
         <Profile
-          followersCount="2950"
-          followingsCount="128"
+          followersCount={UserFollowerCount}
+          followingsCount={UserFollowingCount}
           userImage={UserImage}
           userName={UserName}
           userId={UserAccount}

--- a/src/store/UserInfo.js
+++ b/src/store/UserInfo.js
@@ -6,6 +6,10 @@ const initialState = {
   UserAccount: '',
   UserIntro: '',
   UserImage: '',
+  UserFollowing: '',
+  UserFollower: '',
+  UserFollowerCount: 0,
+  UserFollowingCount: 0,
 };
 
 const UserInfoReducer = (state = initialState, action) => {
@@ -15,6 +19,9 @@ const UserInfoReducer = (state = initialState, action) => {
         ...state,
         UserId: action.UserId,
         UserImage: action.UserImage,
+        UserAccount: action.UserAccount,
+        UserName: action.UserName,
+        UserIntro: action.UserIntro,
         loginToken: action.loginToken,
       };
     case 'JOIN':
@@ -31,6 +38,14 @@ const UserInfoReducer = (state = initialState, action) => {
         UserAccount: action.UserAccount,
         UserIntro: action.UserIntro,
         UserImage: action.UserImage,
+      };
+    case 'FOLLOW':
+      return {
+        ...state,
+        UserFollowing: action.UserFollowing,
+        UserFollower: action.UserFollower,
+        UserFollowerCount: action.UserFollowerCount,
+        UserFollowingCount: action.UserFollowingCount,
       };
     default:
       return state;


### PR DESCRIPTION
1. "/home-empty" 에서 TabMenu의 프로필 버튼을 누르면 로그인 한 계정에 맞는 프로필로 이동하도록 수정하였습니다.
2. 팔로잉 수, 팔로워 수, 프로필 사진, id, 소개도 정상 출력되도록 수정하였습니다. 

저는 [오이마켓](https://market-52.herokuapp.com/profile/aAa)에서 팔로우랑 언팔로우 해가면서 테스트했습니다! 같은 서버 쓰니까 이게 좋네요 ㅋㅋㅋㅋㅋㅋㅋㅋ