### PR TITLE
#146 - Refactor: TabMenu 페이지 연결 및 TopMenuBar 경로 수정

### DIFF
--- a/src/components/TabMenu/TabMenu.jsx
+++ b/src/components/TabMenu/TabMenu.jsx
@@ -9,7 +9,6 @@ import IconUpload from '../../assets/icon/icon-edit.svg';
 import IconMyprofile from '../../assets/icon/icon-user.svg';
 import IconMyprofileHover from '../../assets/icon/icon-user-fill.png';
 
-// import { Link } from 'react-router-dom';
 import { Link, useHistory, useParams } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import axios from 'axios';
@@ -27,6 +26,7 @@ const Footer = styled.ul`
   > li {
     width: 25%;
     padding: 15px 0 10px;
+    cursor: pointer;
     &:hover > p {
       color: var(--color-enabled);
     }
@@ -48,6 +48,7 @@ const Footer = styled.ul`
     text-align: center;
   }
 `;
+
 const GoHome = styled.li`
   &:hover > a {
     background-image: url(${IconHomeHover});
@@ -124,17 +125,25 @@ export default function TabMenu() {
     }
   };
 
+  const upload = () => {
+    history.push('/upload');
+  };
+
+  const chatList = () => {
+    history.push('/chat-list');
+  };
+
   return (
     <Footer>
       <GoHome>
         <GoHomeIcon />
         <p>홈</p>
       </GoHome>
-      <GoChat>
+      <GoChat onClick={chatList}>
         <GoChatIcon />
         <p>채팅</p>
       </GoChat>
-      <GoUpload>
+      <GoUpload onClick={upload}>
         <GoUploadIcon />
         <p>게시물 작성</p>
       </GoUpload>

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { Link, useHistory } from 'react-router-dom';
+import React from 'react';
+import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '../Button/Button';
 
@@ -14,7 +14,6 @@ export default function TopMenuBar({
   moreButton,
   moreButtonSmall,
   menuText,
-  className,
   isEmpty,
   onClick,
   homeText,
@@ -23,10 +22,18 @@ export default function TopMenuBar({
   searchDisplay,
 }) {
   const history = useHistory();
+  const { postId } = useParams();
 
   return (
     <Container>
-      <PreviousBtn onClick={() => history.goBack()} display={preDisplay}>
+      <PreviousBtn
+        onClick={
+          location.pathname === `/post/${postId}`
+            ? () => history.push('/home-empty')
+            : () => history.goBack()
+        }
+        display={preDisplay}
+      >
         <PrevioudBtnImg src={LeftArrow} alt="이전 페이지로 돌아가는 버튼 이미지" />
       </PreviousBtn>
       <SearchModal display={searchDisplay}>


### PR DESCRIPTION
1. TabMenu에 /upload, /chat-list 페이지로 넘어갈 수 있게 추가
2. TopMenuBar의 `PreviousBtn` 경로 수정
게시글 업로드하고 보여지는 페이지에서 뒤로 가기를 누르면 /upload 페이지로 넘어가는 게 불편할 것 같아서 바로 /home-empty으로 넘어가게 해 뒀는데 나중에 홈 피드 완성되면 home-empty에서 피드 뜨는 페이지로 바꾸면 될 것 같습니다!