### PR TITLE
#143 - Refactor: Modal TopMenuBar 연결 및 CSS 깨짐현상 수정

### DIFF
--- a/src/components/Button/MoreButton.jsx
+++ b/src/components/Button/MoreButton.jsx
@@ -7,15 +7,25 @@ import Modal from '../../components/Modal/Modal';
 
 export default function Button({ onClick, size }) {
   const [modal, setModal] = useState(false);
+  const onClickMoreBtn = () => {
+    setModal(true)
+  }
+
+  const handlecloseModal = (state) => {
+    setModal(state)
+  }
+
   return (
-    <ButtonComponent onClick={onClick} size={size}>
-      {onClick}
-      {size === 'large' ? (
-        <Img src={MoreIcon} />
-      ) : size === 'small' ? (
-        <Img src={MoreIconSmall} />
-      ) : null}
-    </ButtonComponent>
+    <>
+      <ButtonComponent onClick={onClickMoreBtn} size={size}>
+        {size === 'large' ? (
+          <Img src={MoreIcon} />
+          ) : size === 'small' ? (
+            <Img src={MoreIconSmall} />
+            ) : null}
+      </ButtonComponent>
+      {modal ? <Modal closeModal={handlecloseModal} isOpened={modal} /> : null}
+    </>
   );
 }
 

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-export default function Modal(display) {
+
+export default function Modal(props) {
+  const onClickMoreBtn = () => {
+    props.closeModal(false)
+  }
   return (
     <>
-      <ChatModal display={display}>
+      <ChatModal onClick={onClickMoreBtn}>
         <ChatModal_Ul>
           <li>
             <Link to="/my-profile">설정 및 개인정보</Link>
@@ -20,14 +25,15 @@ export default function Modal(display) {
 }
 
 const ChatModal = styled.aside`
-  display: none;
-  position: absolute;
-  top: 0px;
-  left: 0px;
-  right: 0px;
-  bottom: 0px;
-  background: rgba(0, 0, 0, 0.3);
-`;
+
+  position:absolute;
+  top:0px;
+  left:0px;
+  right:0px;
+  bottom:0px;
+  background:rgba(0,0,0,0.3);
+  z-index:10;
+`
 
 const ChatModal_Ul = styled.ul`
   position: fixed;
@@ -57,6 +63,9 @@ const ChatModal_Ul = styled.ul`
     font-weight: 400;
     font-size: 14px;
     line-height: 18px;
-    margin-top: 28px;
+    margin-top:28px;
+    >a {
+      display:block
+    }
   }
 `;

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -6,7 +6,6 @@ import Button from '../Button/Button';
 import LeftArrow from '../../assets/icon/icon-arrow-left.png';
 import Search from '../../assets/icon/icon-search.png';
 import MoreButton from '../Button/MoreButton';
-import Modal from '../Modal/Modal';
 
 export default function TopMenuBar({
   saveButton,


### PR DESCRIPTION
1. 모달창을 띄우면 검은 화면이 나와지면서 모달창이 뜹니다
2. 모달창 밖(검은 음영의 부분)을 클릭하면 모달창이 닫힙니다.

모달창이 뜨고 지게 하는것은 true, false값으로 처리했습니다. display를 이용해보려고 했으나 코드가 복잡해지고 꼬이는게 있어 처음에 도움주셨던 true값으로 조정하여 변경했습니다. 인터렉션으로 서서이 올라오게 하는 작업은 미뤄두었습니다. 작동 구현 완료 후에 디자인작업 진행하면서 CSS 인터렉션도 추가해보겠습니다!