### PR TITLE
#169 - Fix: 회원가입 경고 문구 오류 + 계정 ID 정규표현식 오류 수정

### DIFF
--- a/src/components/ProfileForm/ProfileForm.jsx
+++ b/src/components/ProfileForm/ProfileForm.jsx
@@ -67,7 +67,7 @@ export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
 
   // 계정 ID 유효성 검사
   useEffect(() => {
-    const regExp = /^[a-z0-9A-Z_.,()]{1,}$/;
+    const regExp = /^[a-z0-9A-Z_.]{1,}$/;
     if (regExp.test(userAccount) || !userAccount) {
       setIsId(true);
     } else {
@@ -125,7 +125,6 @@ export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
         history.push('/login');
       }
     } catch (error) {
-      console.log(error);
       if (error.response.data.message === '이미 사용중인 계정 ID입니다.') {
         setIsExist(true);
       } else {
@@ -155,10 +154,10 @@ export default function ProfileForm({ isButton, getEmptyInfo, getUserInfo }) {
       <UserInfoInput
         onChange={onHandleUserAccount}
         TitleText="계정 ID"
-        placeholder="영문, 숫자, 특수문자(.),(_)만 사용 가능합니다."
+        placeholder="영문, 숫자, 특수문자(.) , (_)만 사용 가능합니다."
         isLast={false}
       />
-      {isId ? null : <WarningText>* 영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.</WarningText>}
+      {isId ? null : <WarningText>* 영문, 숫자, 특수문자(.) , (_)만 사용 가능합니다.</WarningText>}
       {isExist ? <WarningText>* 이미 사용중인 계정입니다.</WarningText> : null}
       <InputTitle TitleText="소개" />
       <UserInfoInput

--- a/src/pages/Join/Join.jsx
+++ b/src/pages/Join/Join.jsx
@@ -35,7 +35,7 @@ export default function Join() {
     const password = joinPassword;
     const regExp =
       /^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$/i;
-    if (regExp.test(email)) {
+    if (regExp.test(email) || !email) {
       setEmailAvailable(true);
     } else {
       setEmailAvailable(false);
@@ -59,7 +59,6 @@ export default function Join() {
           email: joinId,
         },
       });
-      console.log(res.data.message);
 
       if (res.data.message === '이미 가입된 이메일 주소 입니다.') {
         setIsUser(true);
@@ -75,7 +74,9 @@ export default function Join() {
         history.push('/join/profile');
       }
     } catch (error) {
-      console.log(error);
+      if (error.response.data.message === '잘못된 이메일 형식입니다.') {
+        setEmailAvailable(false);
+      }
     }
   };
 


### PR DESCRIPTION
1. 회원가입 시 이메일 형식이 맞지 않을 때 경고 문구가 발생하지 않는 오류를 수정하였습니다.
2. 계정 ID에 마침표와 언더바만 사용할 수 있도록 정규표현식을 수정하였습니다.