### PR TITLE
#263 - Refactor: 전체적인 마크업 훝어보기

### DIFF
--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -96,7 +96,7 @@ const UserInfo = styled.article`
 `;
 
 // 1
-const FollowArea = styled.div`
+const FollowArea = styled.section`
   margin-bottom: 16px;
   padding: 0 55px;
   display: flex;
@@ -134,7 +134,7 @@ const MyProfileImg = styled.img`
 `;
 
 // 2
-const UserArea = styled.div`
+const UserArea = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/components/TopMenuBar/TopMenuBar.jsx
+++ b/src/components/TopMenuBar/TopMenuBar.jsx
@@ -37,6 +37,7 @@ export default function TopMenuBar({
         <PrevioudBtnImg src={LeftArrow} alt="이전 페이지로 돌아가는 버튼 이미지" />
       </PreviousBtn>
       <SearchModal display={searchDisplay}>
+        <h1 className="ir">계정검색버튼이 있는 검색창입니다.</h1>
         <label htmlFor="search_tit" className="ir">
           검색창입니다
         </label>

--- a/src/pages/ChatList/ChatList.jsx
+++ b/src/pages/ChatList/ChatList.jsx
@@ -78,7 +78,7 @@ const ChatLink = styled(Link)`
   }
 `;
 
-const TextContainer = styled.div`
+const TextContainer = styled.article`
   display: inline-block;
   margin-left: 12px;
   width: 100%;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -11,23 +11,18 @@ import IconMessage from '../../assets/icon/icon-message-circle.png';
 export default function Home({ postList }) {
   const dispatch = useDispatch();
   const history = useHistory();
-  // console.log('하하!!!');
-  // const goToProfile = () => {
-  //   console.log('ㅁㅁㅁ');
-  //   const OtherUserInfo = res.data;
-  //     dispatch({ type: 'FOLLWER', OtherUserInfo });
-  // };
-
   return (
     <>
       <FeedWrap>
         <h1 className="ir">메인화면 피드페이지입니다</h1>
         {postList.map((post) => (
-          // setImgArr(post.image.split(','));
           <MainWrap key={post.createdAt}>
-            <Aside>
-              {/* <Link to={'/profile/' + post.author.accountname}> */}
-              <Img
+            <h1 className="ir">개별 포스트 입니다</h1>
+
+
+            <ProfileWrap>
+              <h1 className="ir">프로필 이미지</h1>
+              <Aside
                 src={post.author.image}
                 onClick={() => {
                   console.log(post.author);
@@ -38,18 +33,23 @@ export default function Home({ postList }) {
                     state: { state: post.author },
                   });
                 }}
-                // onClick={() =>
-                //   history.push({
-                //     pathname: `/profile/${post.author.accountname}`,
-                //     state: { state: post.author },
-                //   })
-                // }
               />
-              {/* </Link> */}
-            </Aside>
+              <UserName
+                onClick={() => {
+                  console.log(post.author);
+                  const OtherUserProfileInfo = post.author;
+                  dispatch({ type: 'PROFILE', OtherUserProfileInfo });
+                  history.push({
+                    pathname: `/your-profile/${post.author.accountname}`,
+                    state: { state: post.author },
+                  });
+                }}>
+                <h2>{post.author.username}</h2>
+                <h3>@ {post.author.accountname}</h3>
+              </UserName>
+            </ProfileWrap>
+
             <Article>
-              <h2>{post.author.username}</h2>
-              <h3>@ {post.author.accountname}</h3>
               <article>{post.content}</article>
               <Content
                 style={
@@ -71,12 +71,12 @@ export default function Home({ postList }) {
                           style={
                             postImage.length > 1
                               ? {
-                                  minWidth: '168px',
-                                  minHeight: '126px',
+                                  width: '100%',
+                                  paddingTop: '100%',
                                   backgroundImage: `url(${image})`,
                                 }
                               : {
-                                  minWidth: '300px',
+                                  width: '100%',
                                   paddingTop: '100%',
                                   backgroundImage: `url(${image})`,
                                 }
@@ -106,6 +106,8 @@ export default function Home({ postList }) {
               </time>
               <MoreButton size={'small'} />
             </Article>
+
+            
           </MainWrap>
         ))}
       </FeedWrap>
@@ -122,10 +124,13 @@ const FeedWrap = styled.main`
   padding: 20px;
 `;
 
-const MainWrap = styled.div`
+const MainWrap = styled.section`
   width: 100%;
   position: relative;
   margin-bottom: 40px;
+  font-family: 'Spoqa Han Sans Neo';
+  font-size: 14px;
+  word-break: keep-all;
   &::before {
     display: block;
     content: '';
@@ -136,52 +141,48 @@ const MainWrap = styled.div`
     right: 0px;
     background: #ddd;
   }
-  &::after {
-    clear: both;
-    content: '';
-    display: block;
-  }
   &:nth-of-type(1)::before {
     display: none;
   }
 `;
-const Aside = styled.aside`
-  float: left;
-  width: 10%;
-  padding-top: 10%;
-  position: relative;
-  overflow: hidden;
-  border-radius: 50%;
-  border: 0.5px solid #dbdbdb;
-  box-sizing: border-box;
-`;
-const Img = styled.img`
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  height: auto;
-  background-size: contain;
-  transform: translate(-50%, -50%);
-  object-fit: cover;
-`;
-const Article = styled.article`
-  float: right;
+
+const ProfileWrap = styled.section`
   display: flex;
-  flex-direction: column;
-  gap: 16px;
-  margin-left: 5%;
-  width: 85%;
-  font-family: 'Spoqa Han Sans Neo';
-  font-size: 14px;
-  word-break: keep-all;
+`
+const UserName = styled.p`
+  padding-top: 5px;
+  margin-left: 1rem;
+  cursor: pointer;
+  > h2 {
+    font-size: 16px;
+    font-weight: bold;
+  }
   > h3 {
-    margin-top: -14px;
     font-size: 12px;
     color: #767676;
   }
-  > article {
-  }
+`;
+
+
+
+
+const Aside = styled.img`
+  width: 40px;
+  height: 40px;
+  object-fit: cover;
+  border-radius: 50%;
+  border: 0.5px solid #dbdbdb;
+  box-sizing: border-box;
+  cursor: pointer;
+`;
+
+const Article = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  margin: 0 3.5rem;
+  width: 85%;
+
   > a {
     > img {
       width: 100%;
@@ -203,12 +204,16 @@ const Content = styled.ul`
   border-radius: 20px;
   display: flex;
   justify-content: space-evenly;
+  gap: 5%;
   > li {
     border-radius: 20px;
     overflow: hidden;
+    width: 100%;
   }
 `;
 const ContImg = styled.div`
+  width: 100%;
+  padding-top: 100%;
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center center;
@@ -222,6 +227,9 @@ const ReactionBtn = styled.ul`
     width: 15px;
     &:nth-child(2) {
       margin-right: 10px;
+    }
+    &:nth-child(3) {
+      cursor: pointer
     }
     img {
       width: 100%;


### PR DESCRIPTION
< 완료작업 >
1. 메인 피드 페이지 이미지가 1개~3개일때 각각 정사각형 이미지로 width에 꽉 차게 보일 수 있도록 수정
2. 메인 피드 프로필 이미지를 aside-img 로 나누는것이 아닌 aside 하나의 태그로 수정하여 object-fit 적용
3. 메인 피드 페이지의 마크업 순서를 변경하여 기존의 (프로필이미지) + (닉넴 + 아이디 + 본문 + 이미지 + 날짜 + 각종버튼)에서 (프로필이미지 + 닉넴 + 아이디 ) + (본문 + 이미지 + 날짜 + 각종버튼)으로 수정 
4. 담당페이지 주석 제거
5. 전체적인 마크업 수정 (div를 조금 시멘틱한 태그로 변경, ir태그 추가 등)
6. 마우스를 가져다 대면 cursor: pointer가 나와야 할것 같은 요소들 태그 추가 (주로 메인피드)

< 해야할 작업 >
1. 업로드 버튼과 회원가입 버튼의 색상적용을 떨어트려서 개별로 적용하게끔 작업.